### PR TITLE
ci: bump CI docker image to v0.17.4

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.11.13
+      image: zephyrprojectrtos/ci:v0.17.4
 
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/sdk/zephyr-sdk-0.12.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
-image: zephyrprojectrtos/ci:v0.11.15
+image: zephyrprojectrtos/ci:v0.17.4
 
 variables:
   GIT_STRATEGY: none
   ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-  ZEPHYR_SDK_INSTALL_DIR: /opt/sdk/zephyr-sdk-0.12.3
+  ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
 
 .west-init-and-update: &west-init-and-update
   - rm -rf .west modules/lib/golioth


### PR DESCRIPTION
This is the latest release containining newest Zephyr SDK.