### PR TITLE
add west-zephyr.yml and simplify west.yml

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -29,7 +29,7 @@ jobs:
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth
-          file = west.yml
+          file = west-zephyr.yml
           EOF
 
           west update -o=--depth=1 -n

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -25,7 +25,7 @@ jobs:
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth
-          file = west.yml
+          file = west-zephyr.yml
           EOF
 
           west update -o=--depth=1 -n zephyr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
 
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth
-  - west init -m $CI_REPOSITORY_URL
+  - west init -m $CI_REPOSITORY_URL --mr $CI_COMMIT_REF_NAME
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
   - west forall -c 'git clean -ffdx && git reset --hard'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ variables:
 
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth
-  - west init -m $CI_REPOSITORY_URL --mr $CI_COMMIT_REF_NAME
+  - west init -m $CI_REPOSITORY_URL --mf west-zephyr.yml --mr $CI_COMMIT_REF_NAME
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
   - west forall -c 'git clean -ffdx && git reset --hard'
 
@@ -146,9 +146,7 @@ twister-ncs:
             path: modules/lib/golioth
             revision: $CI_COMMIT_SHA
             url: $CI_REPOSITORY_URL
-            import:
-              name-allowlist:
-                - qcbor
+            import: west-external.yml
       EOF
     - |
       cat <<EOF >> nrf/west.yml

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Execute this command to download this repository together with all dependencies:
 
 .. code-block:: console
 
-   west init -m https://github.com/golioth/golioth-zephyr-sdk.git
+   west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mf west-zephyr.yml
    west update
 
 Adding Golioth SDK to existing west project
@@ -32,9 +32,7 @@ subtree of existing `west`_ based project (e.g. Zephyr RTOS):
       path: modules/lib/golioth
       revision: main
       url: https://github.com/golioth/golioth-zephyr-sdk.git
-      import:
-        name-allowlist:
-          - qcbor
+      import: west-external.yml
 
 and clone all repositories including that one by running:
 

--- a/west-external.yml
+++ b/west-external.yml
@@ -1,0 +1,6 @@
+manifest:
+  projects:
+    - name: qcbor
+      revision: 17b5607b8c49b835d22dec3effa97b25c89267b3
+      url: https://github.com/golioth/QCBOR.git
+      path: modules/lib/qcbor

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -7,11 +7,7 @@ manifest:
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 
-    - name: qcbor
-      revision: 17b5607b8c49b835d22dec3effa97b25c89267b3
-      url: https://github.com/golioth/QCBOR.git
-      path: modules/lib/qcbor
-
   self:
     path: modules/lib/golioth
     west-commands: scripts/west-commands.yml
+    import: west-external.yml

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -19,11 +19,7 @@ manifest:
           - tinycbor
           - tinycrypt
 
-    - name: qcbor
-      revision: 17b5607b8c49b835d22dec3effa97b25c89267b3
-      url: https://github.com/golioth/QCBOR.git
-      path: modules/lib/qcbor
-
   self:
     path: modules/lib/golioth
     west-commands: scripts/west-commands.yml
+    import: west-external.yml


### PR DESCRIPTION
Add west-zephyr.yml root manifest for use cases when Golioth SDK is used
with vanilla Zephyr.

Add west-external.yml file with SDK-specific (not used by vanilla Zephyr
and/or NCS) dependencies, so that this file can be included from any
manifest file (either SDK's west-zephyr.yml, west-ncs.yml or standalone
application).

As a result there are 3 west manifest files provided in this repo:

 * west-external.yml - generic manifest file specifying 'qcbor' library
   as the only dependency (for now); this file is to be included by
   standalone applications, which select their own version of Zephyr
   RTOS and/or nRF Connect SDK,

 * west-zephyr.yml - manifest file specifying Zephyr RTOS as dependency;
   can be used as root west manifest (to try out samples/ with vanilla
   Zephyr) or by standalone application that relies on Golioth SDK to
   select Zephyr RTOS version,

 * west-ncs.yml - manifest file specifying nRF Connect SDK as
   dependency; can be used as root west manifest (to try out samples/
   with NCS) or by standalone application that relies on Golioth SDK to
   select NCS version.

Remove 'west.yml' file, so that it does not confuse users about what use
case (from above mentioned) it covers.

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/192"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

