### PR TITLE
Bump NCS to tip of main

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.19.0
+      image: zephyrprojectrtos/ci:v0.23.1
 
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.18.3
+      image: zephyrprojectrtos/ci:v0.23.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,11 @@
 image: zephyrprojectrtos/ci:v0.23.1
 
+variables:
+  WEST_MANIFEST: west.yml
+
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth
-  - west init -m $CI_REPOSITORY_URL
+  - west init -m $CI_REPOSITORY_URL --mf ${WEST_MANIFEST}
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
 
 .cache-deps: &cache-deps
@@ -137,28 +140,8 @@ twister-esp:
 
 twister-ncs:
   extends: .twister
-  before_script:
-    - rm -rf .west nrf
-    - west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1
-    - west forall -c 'git clean -ffdx && git reset --hard'
-    - mkdir -p nrf/submanifests
-    - |
-      cat <<EOF > nrf/submanifests/golioth.yaml
-      manifest:
-        projects:
-          - name: golioth
-            path: modules/lib/golioth
-            revision: $CI_COMMIT_SHA
-            url: $CI_REPOSITORY_URL
-            import:
-              name-allowlist:
-                - qcbor
-      EOF
-    - |
-      cat <<EOF >> nrf/west.yml
-          import: submanifests
-      EOF
-    - west update -o=--depth=1 -n
+  variables:
+    WEST_MANIFEST: west-ncs.yml
   script:
     - >
       zephyr/scripts/twister

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ image: zephyrprojectrtos/ci:v0.23.1
   - rm -rf .west modules/lib/golioth
   - west init -m $CI_REPOSITORY_URL
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
-  - west forall -c 'git clean -ffdx && git reset --hard'
 
 .cache-deps: &cache-deps
   key: west-modules
@@ -37,7 +36,11 @@ stages:
     policy: pull
   before_script:
     - *west-init
-    - west update -o=--depth=1 -n
+    - >
+      west update -o=--depth=1 -n ||
+      (west forall -c 'git clean -ffdx && git reset --hard' &&
+       west update -o=--depth=1 -n)
+    - west forall -c 'git clean -ffdx && git reset --hard'
     - west patch --apply
 
 .west-build:
@@ -62,7 +65,11 @@ checkpatch:
   before_script:
     - *west-init
     - west update modules/lib/golioth
-    - west update zephyr -o=--depth=1 -n
+    - >
+      west update zephyr -o=--depth=1 -n ||
+      (west forall -c 'git clean -ffdx && git reset --hard' &&
+       west update zephyr -o=--depth=1 -n)
+    - west forall -c 'git clean -ffdx && git reset --hard'
   script:
     - cd modules/lib/golioth
     - git fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,4 @@
-image: zephyrprojectrtos/ci:v0.19.0
-
-variables:
-  ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
+image: zephyrprojectrtos/ci:v0.23.1
 
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth

--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -15,6 +15,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -15,6 +15,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v1.7.1
+      revision: 5813de2c78645d6436c479ed68973914882b7939
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 


### PR DESCRIPTION
After commit "lib: nrf_modem: don't enforce socket priority over native
TLS" was merged into 'main' branch it is possible to configure priority
of Zephyr TLS implementation to be higher than offloaded nRF9160 TLS.
This makes it possible to select Zephyr TLS (mbedTLS) implementation at
build time, which was not possible from NCS 1.8.0.

Update also CI scripts to be able to build newest NCS.

Solves: #158

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/193"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

