### PR TITLE
docs: fix broken link to prod docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The latest Doxygen documentation can be viewed here:
 
-https://golioth-zephyr-sdk-doxygen-prod.firebaseapp.com/
+https://golioth-zephyr-sdk-doxygen.firebaseapp.com/
 
 
 ### Building Doxygen Locally


### PR DESCRIPTION
In my haste to fix broken CI in #194, I failed to check
the whether the README link was valid.

Signed-off-by: Nick Miller <nick@golioth.io>

<a href="https://gitpod.io/#https://github.com/golioth/zephyr-sdk/pull/195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

