### PR TITLE
gitlint: match max title length restriction with checkpatch

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -4,4 +4,4 @@
 extra-path=scripts/gitlint
 
 [body-max-line-length]
-line-length=72
+line-length=75


### PR DESCRIPTION
Initial gitlint configuration was generated based on old Zephyr .gitlint
file. Newest version specifies 75 line-length, which is in sync with
checkpatch and editorconfig tools. Update our .gitlint file to 75 line
lengths.