### PR TITLE
ci: update Zephyr CI image to v0.23.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.19.0
+      image: zephyrprojectrtos/ci:v0.23.1
 
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.18.3
+      image: zephyrprojectrtos/ci:v0.23.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,4 @@
-image: zephyrprojectrtos/ci:v0.19.0
-
-variables:
-  ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
+image: zephyrprojectrtos/ci:v0.23.1
 
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth


### PR DESCRIPTION
Newer 'west' version is needed (>= 0.12.0) in order to import NCS
successfully. Bump CI image now, so that 'west' does not need to be
overridden manually.

This updates Zephyr SDK version to 0.14.1

Remove manual configuration of ZEPHYR_SDK_INSTALL_DIR environment
variable from GitLab CI, as SDK is successfully found in CI image using
CMake package registry. Leave (and update) that environment variable in
GitHub Workflows, as GitHub CI uses different path as
$HOME (/github/home/ instead of /root/), which makes CMake package
registry (at /root/.cmake/) not visible.