### PR TITLE
gitlab-ci: use west-ncs.yml for 'twister-ncs' job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,6 @@ image: zephyrprojectrtos/ci:v0.23.1
   - rm -rf .west modules/lib/golioth
   - west init -m $CI_REPOSITORY_URL --mf west-zephyr.yml --mr $CI_COMMIT_REF_NAME
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
-  - west forall -c 'git clean -ffdx && git reset --hard'
 
 .cache-deps: &cache-deps
   key: west-modules
@@ -37,7 +36,11 @@ stages:
     policy: pull
   before_script:
     - *west-init
-    - west update -o=--depth=1 -n
+    - >
+      west update -o=--depth=1 -n ||
+      (west forall -c 'git clean -ffdx && git reset --hard' &&
+       west update -o=--depth=1 -n)
+    - west forall -c 'git clean -ffdx && git reset --hard'
     - west patch --apply
 
 .west-build:
@@ -62,7 +65,11 @@ checkpatch:
   before_script:
     - *west-init
     - west update modules/lib/golioth
-    - west update zephyr -o=--depth=1 -n
+    - >
+      west update zephyr -o=--depth=1 -n ||
+      (west forall -c 'git clean -ffdx && git reset --hard' &&
+       west update zephyr -o=--depth=1 -n)
+    - west forall -c 'git clean -ffdx && git reset --hard'
   script:
     - cd modules/lib/golioth
     - git fetch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,11 @@
 image: zephyrprojectrtos/ci:v0.23.1
 
+variables:
+  WEST_MANIFEST: west-zephyr.yml
+
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth
-  - west init -m $CI_REPOSITORY_URL --mf west-zephyr.yml --mr $CI_COMMIT_REF_NAME
+  - west init -m $CI_REPOSITORY_URL --mf ${WEST_MANIFEST} --mr $CI_COMMIT_REF_NAME
   - (cd modules/lib/golioth; git checkout $CI_COMMIT_SHA)
 
 .cache-deps: &cache-deps
@@ -137,26 +140,8 @@ twister-esp:
 
 twister-ncs:
   extends: .twister
-  before_script:
-    - rm -rf .west nrf
-    - west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1
-    - west forall -c 'git clean -ffdx && git reset --hard'
-    - mkdir -p nrf/submanifests
-    - |
-      cat <<EOF > nrf/submanifests/golioth.yaml
-      manifest:
-        projects:
-          - name: golioth
-            path: modules/lib/golioth
-            revision: $CI_COMMIT_SHA
-            url: $CI_REPOSITORY_URL
-            import: west-external.yml
-      EOF
-    - |
-      cat <<EOF >> nrf/west.yml
-          import: submanifests
-      EOF
-    - west update -o=--depth=1 -n
+  variables:
+    WEST_MANIFEST: west-ncs.yml
   script:
     - >
       zephyr/scripts/twister


### PR DESCRIPTION
So far NCS' west manifest file was patched in order to include Golioth
SDK as west module. Use 'west-ncs.yml', so that west workspace
initialization is simplified and the correct version is not hardcoded
into CI script.

Depends on (and contains commits from): #201