### PR TITLE
settings: enable CONFIG_REBOOT

### DIFF
--- a/samples/settings/prj.conf
+++ b/samples/settings/prj.conf
@@ -8,6 +8,7 @@ CONFIG_NET_LOG=y
 
 # Network Shell
 CONFIG_NET_SHELL=y
+CONFIG_REBOOT=y
 
 # TLS configuration
 CONFIG_MBEDTLS_ENABLE_HEAP=y


### PR DESCRIPTION
The settings sample needs to be able to reboot via shell
after setting WiFi and Golioth credentials, so
CONFIG_REBOOT is required to enable the "kernel reboot cold/warm"
commands.

Signed-off-by: Nick Miller <nick@golioth.io>