### PR TITLE
samples: settings: remove comment about bootloader mode for nRF91 DK

### DIFF
--- a/samples/settings/README.rst
+++ b/samples/settings/README.rst
@@ -82,8 +82,7 @@ nRF9160 DK
 On your host computer open a terminal window, locate the directory that contains
 the sample folder (i.e., ``~/zephyr-nrf/modules/lib/golioth``). We will build it
 without assigning any Golioth credentials, and this sample automatically builds
-for MCUboot. Build and flash examples are below (remember to put the device in
-bootloader mode):
+for MCUboot. Build and flash examples are below:
 
 .. code-block:: console
 


### PR DESCRIPTION
This is a leftover from nRF91 Feather and Thingy:91. In case of DK, there
is no bootloader mode.