### PR TITLE
west-zephyr: remove unused ST hal

### DIFF
--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -9,8 +9,6 @@ manifest:
           - cmsis
           - hal_espressif
           - hal_nordic
-          - hal_st
-          - hal_stm32
           - mbedtls
           - mcuboot
           - net-tools


### PR DESCRIPTION
ST hal libraries were added as there was work in progress that was adding
STM32 platforms support to samples. This won't happen in the close future
however, so remove unused HAL libraries.