### PR TITLE
bump Zephyr and NCS to tip of main

### DIFF
--- a/samples/dfu/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/dfu/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/hello/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/hello/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -15,6 +15,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/hello_sporadic/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/hello_sporadic/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -15,6 +15,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/get/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/get/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/observe/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/observe/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb/set/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/set/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb_led/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb_led/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -27,7 +27,7 @@ static struct coap_reply coap_replies[1];
 		    ())
 
 static struct gpio_dt_spec led[] = {
-	UTIL_LISTIFY(10, LED_GPIO_SPEC)
+	LISTIFY(10, LED_GPIO_SPEC, ())
 };
 
 static void golioth_led_initialize(void)

--- a/samples/lightdb_stream/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb_stream/boards/nrf52840dk_nrf52840.overlay
@@ -10,10 +10,23 @@
 	};
 };
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/logging/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/logging/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/samples/settings/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/settings/boards/nrf52840dk_nrf52840.overlay
@@ -4,10 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&uart1_default {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+	};
+};
+
+&uart1_sleep {
+	cts-rts {
+		psels = <NRF_PSEL(UART_CTS, 1, 3)>,
+			<NRF_PSEL(UART_RTS, 1, 4)>;
+		low-power-enable;
+	};
+};
+
 &uart1 {
 	status = "okay";
-	cts-pin = <35>;
-	rts-pin = <36>;
 	hw-flow-control;
 
 	esp_wifi: esp-wifi {

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -10,6 +10,10 @@ CONFIG_NET_SOCKETS_OFFLOAD=y
 # modem library.
 CONFIG_NET_SOCKETS_OFFLOAD_TLS=n
 
+# Increase native TLS socket implementation, so that it is chosen instead of
+# offloaded nRF91 sockets
+CONFIG_NET_SOCKETS_TLS_PRIORITY=35
+
 # LTE link control
 CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_AUTO_INIT_AND_CONNECT=y

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v1.7.1
+      revision: 540ed5b0515280bba53673233d167b0eca523048  # post v1.9.0
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: v3.0.0
+      revision: 05cc2e1ac3887bd4c7a23a098d27eee65f154b47  # post v3.0.0
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
After commit "lib: nrf_modem: don't enforce socket priority over native
TLS" was merged into 'main' branch of NCS it is possible to configure priority
of Zephyr TLS implementation to be higher than offloaded nRF9160 TLS.
This makes it possible to select Zephyr TLS (mbedTLS) implementation at
build time, which was not possible from NCS 1.8.0.

In case of Zephyr there are numerous networking stack and esp-at driver 
bugfixes in main branch.

Resolves: #158
Closes: #190 #193