### PR TITLE
docs: update URL of deployed doxygen site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The latest Doxygen documentation can be viewed here:
 
-https://golioth-zephyr-sdk-doxygen.firebaseapp.com/
+https://zephyr-sdk-docs.golioth.io/
 
 
 ### Building Doxygen Locally


### PR DESCRIPTION
Docs are now deployed to zephyr-sdk-docs.golioth.io when
PRs merge to main.

Signed-off-by: Nick Miller <nick@golioth.io>