### PR TITLE
ci: update Zephyr CI image to v0.23.3

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.23.1
+      image: zephyrprojectrtos/ci:v0.23.3
 
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.1
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.23.1
+      image: zephyrprojectrtos/ci:v0.23.3
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,10 +128,7 @@ twister:
 twister-esp:
   extends: .twister
   script:
-    - west espressif install
     - west espressif update
-    - export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
-    - export ESPRESSIF_TOOLCHAIN_PATH="${HOME}/.espressif/tools/zephyr"
     - >
       zephyr/scripts/twister
       -p esp32

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: zephyrprojectrtos/ci:v0.23.1
+image: zephyrprojectrtos/ci:v0.23.3
 
 variables:
   WEST_MANIFEST: west-zephyr.yml


### PR DESCRIPTION
This updates Zephyr SDK version to 0.14.2.

Remove also `west espressif install` from GitLab CI, as it is no longer needed.