### PR TITLE
net: golioth: fix golioth_sendmsg() return code check

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -299,7 +299,13 @@ static int golioth_sendmsg(struct golioth_client *client,
 
 	free(data);
 
-	return ret;
+	if (ret < 0) {
+		return ret;
+	} else if (ret < len) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int golioth_send_coap(struct golioth_client *client, struct coap_packet *packet)
@@ -341,7 +347,6 @@ int golioth_send_coap_payload(struct golioth_client *client,
 		.msg_iov = msg_iov,
 		.msg_iovlen = ARRAY_SIZE(msg_iov),
 	};
-	int ret;
 	int err;
 
 	if (client->proto == IPPROTO_UDP) {
@@ -371,7 +376,7 @@ int golioth_send_coap_payload(struct golioth_client *client,
 	msg_iov[1].iov_base = payload;
 	msg_iov[1].iov_len = payload_len;
 
-	ret = golioth_sendmsg(client, &msg, 0);
+	err = golioth_sendmsg(client, &msg, 0);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
Return code was saved to 'ret' variable, but 'err' variable was checked in
the next like instead.

In fact number of sent bytes should be compared with the number returned
from underlying zsock_send() call. Do exactly that inside
golioth_sendmsg(), as that function contains number of total bytes that
should be sent. Change golioth_sendmsg() behavior to return 0 in case of
success and negative value in case of error.

Save value returned from golioth_sendmsg() to 'err', which by convention
can be 0 (success) or negative (error).

Reported-by: Nick Miller <nick@golioth.io>