### PR TITLE
net: golioth: fix golioth_send{,msg}() error path (again)

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -236,6 +236,8 @@ static int __golioth_send(struct golioth_client *client, uint8_t *data,
 	sent = zsock_send(client->sock, data, len, flags);
 	if (sent < 0) {
 		return -errno;
+	} else if (sent < len) {
+		return -EIO;
 	}
 
 	return 0;
@@ -299,13 +301,7 @@ static int golioth_sendmsg(struct golioth_client *client,
 
 	free(data);
 
-	if (ret < 0) {
-		return ret;
-	} else if (ret < len) {
-		return -EIO;
-	}
-
-	return 0;
+	return ret;
 }
 
 int golioth_send_coap(struct golioth_client *client, struct coap_packet *packet)


### PR DESCRIPTION
Both golioth_send() and golioth_sendmsg() use __golioth_send().
__golioth_send() already converts zsock_send() error codes from:

 * -1 (with errno) - in case of error
 * number of bytes sent - in case of success

into:

 * -errno - in case of zsock_send() error
 * 0 - in case of success

Similar logic was implemented in golioth_sendmsg(). Additionally
golioth_sendmsg() checks now for number of bytes actually sent, so that
truncated datagrams can be detected, in which case -EIO is returned. This
behavior is wrong, as __golioth_send() never returns positive values, so
golioth_sendmsg() always ends up returning -EIO.

Fix above issue by moving the check for truncated packets into
__golioth_send() function. It will now return following values:

 * -errno - in case of zsock_send() error
 * -EIO - in case of truncated datagram (less bytes sent than requested)
 * 0 - in case of success

This is already what golioth_sendmsg() tried to return, so just pass the
return value directly to caller, without any further checking in
golioth_sendmsg().

Fixes: 96d31d453881 ("net: golioth: fix golioth_sendmsg() return code
  check")