### PR TITLE
logging: fix Golioth backend registration

### DIFF
--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -737,7 +737,7 @@ int log_backend_golioth_init(struct golioth_client *client)
 {
 	log_ctx.client = client;
 
-	log_backend_activate(&log_backend_golioth, &log_ctx);
+	log_backend_enable(&log_backend_golioth, &log_ctx, CONFIG_LOG_MAX_LEVEL);
 
 	return 0;
 }


### PR DESCRIPTION
When "autostart" argument is "true" in LOG_BACKEND_DEFINE() invocation,
then log_backend_enable() is called automatically during system boot. In
case of Golioth backend autostart is disabled due to dependency on Golioth
client instance initialization in application code.

log_backend_activate() was called so far in order to "plug in" Golioth
logging backend. However this does just part of the job of
log_backend_enable(), because it does not assign log id and setup log
filters. Those are required in order to make log filtering work for Golioth
backend.

Fix Golioth logging backend initialization (which includes log filtering
capabilities) by calling log_backend_enable() instead of
log_backend_activate().

Signed-off-by: Marcin Niestroj <m.niestroj@emb.dev>