### PR TITLE
west: bump Zephyr to 3.1.0 and NCS to 2.0.0

### DIFF
--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -29,3 +29,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -29,3 +29,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -24,3 +24,6 @@ CONFIG_NRF_MODEM_LIB=y
 # Offloaded poll() does not support external events like eventfd, so use timeout
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+
+# Conflicts with MBEDTLS_DTLS
+CONFIG_BUILD_WITH_TFM=n

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: 540ed5b0515280bba53673233d167b0eca523048  # post v1.9.0
+      revision: v2.0.0
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: 05cc2e1ac3887bd4c7a23a098d27eee65f154b47  # post v3.0.0
+      revision: v3.1.0
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
Both are the latest stable releases.