### PR TITLE
treewide: prepend zephyr/ to all Zephyr include paths

### DIFF
--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -7,10 +7,10 @@
 #ifndef GOLIOTH_INCLUDE_NET_GOLIOTH_H_
 #define GOLIOTH_INCLUDE_NET_GOLIOTH_H_
 
-#include <kernel.h>
-#include <net/coap.h>
-#include <net/tls_credentials.h>
 #include <stdint.h>
+#include <zephyr/kernel.h>
+#include <zephyr/net/coap.h>
+#include <zephyr/net/tls_credentials.h>
 
 /**
  * @defgroup net Golioth Networking

--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log_backend.h>
-#include <logging/log_ctrl.h>
-#include <logging/log_core.h>
-#include <logging/log_output.h>
 #include <net/golioth.h>
-#include <sys/cbprintf.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log_output.h>
+#include <zephyr/sys/cbprintf.h>
 #include <qcbor/posix_error_map.h>
 #include <qcbor/qcbor.h>
 

--- a/net/golioth/coap_utils.c
+++ b/net/golioth/coap_utils.c
@@ -6,7 +6,7 @@
 
 #include "coap_utils.h"
 
-#include <net/coap.h>
+#include <zephyr/net/coap.h>
 
 int coap_packet_append_uri_path_from_string_range(struct coap_packet *packet,
 						  const char *begin,

--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -13,7 +13,7 @@
 
 #include "coap_utils.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth);
 
 #define GOLIOTH_FW_DOWNLOAD	".u"

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <net/coap.h>
+#include <zephyr/net/coap.h>
 #include <net/golioth.h>
-#include <net/socket.h>
-#include <random/rand32.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/random/rand32.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "coap_utils.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth, CONFIG_GOLIOTH_LOG_LEVEL);
 
 #define COAP_BASIC_HEADER_SIZE	4

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_LOG_LEVEL);
 
 #include <errno.h>
 #include <logging/golioth.h>
 #include <net/golioth/system_client.h>
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <posix/sys/eventfd.h>
-#include <settings/settings.h>
-#include <sys/atomic.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/posix/sys/eventfd.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/atomic.h>
 
 #define USE_EVENTFD							\
 	IS_ENABLED(CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_EVENTFD)

--- a/samples/common/settings_autoload.c
+++ b/samples/common/settings_autoload.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <settings/settings.h>
+#include <zephyr/init.h>
+#include <zephyr/settings/settings.h>
 
 static int settings_autoload(const struct device *dev)
 {

--- a/samples/common/settings_shell.c
+++ b/samples/common/settings_shell.c
@@ -4,15 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <shell/shell.h>
-#include <sys/printk.h>
-#include <init.h>
-#include <ctype.h>
-
-#include <settings/settings.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/sys/printk.h>
 
 struct settings_read_callback_params {
 	const struct shell *shell_ptr;

--- a/samples/common/wifi.c
+++ b/samples/common/wifi.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_wifi, LOG_LEVEL_DBG);
 
 #include <samples/common/wifi.h>
-#include <net/wifi_mgmt.h>
-#include <settings/settings.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/settings/settings.h>
 
 struct wifi_data {
 	struct net_mgmt_event_callback wifi_mgmt_cb;

--- a/samples/dfu/src/flash.c
+++ b/samples/dfu/src/flash.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth_dfu);
 
 #include <stdio.h>
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 
 #include "flash.h"
 

--- a/samples/dfu/src/flash.h
+++ b/samples/dfu/src/flash.h
@@ -9,8 +9,8 @@
 
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 
-#include <dfu/flash_img.h>
-#include <dfu/mcuboot.h>
+#include <zephyr/dfu/flash_img.h>
+#include <zephyr/dfu/mcuboot.h>
 #include <zephyr/types.h>
 
 int flash_img_prepare(struct flash_img_context *flash);

--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_dfu, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/fw.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
 
-#include <logging/log_ctrl.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/reboot.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/net/coap.h>
+#include <zephyr/sys/reboot.h>
 
 #include "flash.h"
 

--- a/samples/hello/src/main.c
+++ b/samples/hello/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_hello, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 

--- a/samples/hello_sporadic/src/main.c
+++ b/samples/hello_sporadic/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_hello, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 

--- a/samples/lightdb/get/src/main.c
+++ b/samples/lightdb/get/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_lightdb, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
 #include <stdlib.h>
 

--- a/samples/lightdb/observe/src/main.c
+++ b/samples/lightdb/observe/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_lightdb, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
 #include <stdlib.h>
 

--- a/samples/lightdb/set/src/main.c
+++ b/samples/lightdb/set/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_lightdb, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
 #include <stdlib.h>
 

--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_lightdb, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 #include <stdlib.h>
 #include <qcbor/qcbor.h>
 #include <qcbor/qcbor_decode.h>

--- a/samples/lightdb_stream/src/main.c
+++ b/samples/lightdb_stream/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_lightdb_stream, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/net/coap.h>
 
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdlib.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();

--- a/samples/logging/src/main.c
+++ b/samples/logging/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_logging, LOG_LEVEL_DBG);
 
-#include <net/coap.h>
-#include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <net/golioth/system_client.h>
+#include <zephyr/net/coap.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 

--- a/samples/settings/src/main.c
+++ b/samples/settings/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth_hello, LOG_LEVEL_DBG);
 
-#include <init.h>
-#include <net/coap.h>
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>
+#include <zephyr/init.h>
+#include <zephyr/net/coap.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 


### PR DESCRIPTION
Make code compatible with CONFIG_LEGACY_INCLUDE_PATH=n.

Not all Zephyr modules are compatible with this change, which is why
we have to wait before merging. Right now it it hard to verify that all
headers were converted properly.