### PR TITLE
github: skip deploying docs to dev if in fork PR

### DIFF
--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -11,7 +11,10 @@ jobs:
         run: |
           cd docs/doxygen
           doxygen
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Deploy docs to dev
+        # The 'if' will prevent running this step if in a fork pull request
+        if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GOLIOTH }}'


### PR DESCRIPTION
For security reasons, Github does not allow forks to have
access to Actions secrets, which prevents the
firebase-doxygen-pr.yml workflow from completing due
to not having access to
secrets.FIREBASE_SERVICE_ACCOUNT_GOLIOTH.

With this change, we will skip the deployment step for
fork PRs.

Signed-off-by: Nick Miller <nick@golioth.io>