### PR TITLE
net: golioth: system_client: add Kconfig configurable thread priority

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -60,6 +60,12 @@ config GOLIOTH_SYSTEM_CLIENT_STACK_SIZE
 	help
 	  Defines system client thread stack size.
 
+config GOLIOTH_SYSTEM_CLIENT_THREAD_PRIORITY
+	int "Thread priority"
+	default 14
+	help
+	  Priority at which the Golioth client system thread runs.
+
 config GOLIOTH_SYSTEM_SERVER_HOST
 	string "Server Host"
 	default "coap.golioth.io" if ((NET_NATIVE && NET_IPV4 && DNS_RESOLVER) || NET_SOCKETS_OFFLOAD)

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -394,7 +394,7 @@ static void golioth_system_client_main(void *arg1, void *arg2, void *arg3)
 K_THREAD_DEFINE(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_STACK_SIZE,
 		golioth_system_client_main,
 		GOLIOTH_SYSTEM_CLIENT_GET(), NULL, NULL,
-		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
+		CONFIG_GOLIOTH_SYSTEM_CLIENT_THREAD_PRIORITY, 0, 0);
 
 void golioth_system_client_start(void)
 {


### PR DESCRIPTION
So far system client priority was hardcoded to the lowest application
priority. Introduce a Kconfig option that defaults to the same, but allows
to configure it per application needs.