### PR TITLE
changelog: fix release date of 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2021-05-06
+## [0.1.0] - 2022-05-06
 ### Added
 - Initial release, verified with Zephyr version 3.0.0 and NCS version 1.7.1.


### PR DESCRIPTION
It was 2022, not 2021.