### PR TITLE
enforce DTLS handshake in golioth_connect() and add golioth_is_connected()

### DIFF
--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -143,6 +143,18 @@ static inline void golioth_unlock(struct golioth_client *client)
 void golioth_init(struct golioth_client *client);
 
 /**
+ * @brief Check if client is connected to Golioth
+ *
+ * Check if client instance is connected to Golioth.
+ *
+ * @param client Client instance.
+ *
+ * @retval true When client is connected to Golioth.
+ * @retval false When client is not connected to Golioth.
+ */
+bool golioth_is_connected(struct golioth_client *client);
+
+/**
  * @brief Connect to Golioth
  *
  * Attempt to connect to Golioth.

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -28,6 +28,17 @@ void golioth_init(struct golioth_client *client)
 	client->sock = -1;
 }
 
+bool golioth_is_connected(struct golioth_client *client)
+{
+	bool is_connected;
+
+	k_mutex_lock(&client->lock, K_FOREVER);
+	is_connected = (client->sock >= 0);
+	k_mutex_unlock(&client->lock);
+
+	return is_connected;
+}
+
 static int golioth_setsockopt_dtls(struct golioth_client *client, int sock)
 {
 	int ret;


### PR DESCRIPTION
As per `connect(3)` manpages:

```
  The connect() function shall attempt to make a connection on a
  connection-mode socket or to set or reset the peer address of a
  connectionless-mode socket.
```

and:

```
  If the initiating socket is connection-mode, then connect() shall attempt
  to establish a connection to the address specified by the address
  argument. If the connection cannot be established immediately and
  O_NONBLOCK is not set for the file descriptor for the socket, connect()
  shall block for up to an unspecified timeout interval until the
  connection is established.
```

RFC 6347 (DTLS 1.2) interchangably uses the terms association, session and
connection. Though it is not specified in neither POSIX nor Zephyr how DTLS
sockets should be treated (they are really just Zephyr extension), it seems
natural to assume they are "connection-mode" sockets as per `connect()`
POSIX documentation.

Because of the reasons described above, make sure that golioth_connect()
does the DTLS handshake in order to "establish a connection". As Zephyr's
connect() call does not result in such behavior, issue send() with an empty
CoAP packet, so that the DTLS handshake is done as part of that API call.

Add golioth_is_connected(), which simply returns whether client is
connected to Golioth server. This is true whenever DTLS layer has
finished (first) handshake.