### PR TITLE
west-zephyr: bump MCUboot to include fix for ESP32

### DIFF
--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -10,10 +10,14 @@ manifest:
           - hal_espressif
           - hal_nordic
           - mbedtls
-          - mcuboot
           - net-tools
           - segger
           - tinycrypt
+
+    - name: mcuboot
+      revision: e7415b555134e671ba04f036b02f55cbc087d0e9
+      path: bootloader/mcuboot
+      url: https://github.com/zephyrproject-rtos/mcuboot
 
   self:
     path: modules/lib/golioth


### PR DESCRIPTION
ESP32 platform had broken chain-loading of application image at least
starting from Zephyr 2.7.0 stable release and it was still not fixed with
the release of 3.1.0.

In fact the problem is in MCUboot bootloader, but it is Zephyr which
decides what version of MCUboot is pulled in.

Change revision of MCUboot that is used with west-zephyr.yml manifest file
to a version that contains a fix for ESP32 application chain-loading.
Fortunately used revision contains only this single fix (compared to
revision pulled in by Zephyr 3.1.0), so there is no risk of breaking other
functionalities/platforms.

Split from #227