### PR TITLE
samples: lightdb_led: reset QCBOR error after "no more items"

### DIFF
--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -116,6 +116,8 @@ static int golioth_led_handle(const struct coap_packet *response,
 
 		qerr = QCBORDecode_GetError(&decode_ctx);
 		if (qerr == QCBOR_ERR_NO_MORE_ITEMS) {
+			/* Reset decoding error, as "no more items" was expected */
+			QCBORDecode_GetAndResetError(&decode_ctx);
 			break;
 		}
 


### PR DESCRIPTION
While loop is expected to run until "no more items" condition is reached.
Clear that decoding error, so that further processing can rely on
QCBOR_SUCCESS code.

Fixes: #220 