### PR TITLE
net: golioth: system_client: add configurable TLS credentials tag

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -67,6 +67,16 @@ config GOLIOTH_SYSTEM_CLIENT
 
 if GOLIOTH_SYSTEM_CLIENT
 
+config GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG
+	int "TLS credentials secure tag"
+	default 515765868
+	help
+	  Secure tag, which is a reference to TLS credential. This value is
+	  configured on created (D)TLS socket in order reference credentials
+	  used during connection handshake.
+
+	  See 'sec_tag_t' typedef in Zephyr for details.
+
 config GOLIOTH_SYSTEM_CLIENT_STACK_SIZE
 	int "Stack size"
 	default 3072

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -45,8 +45,6 @@ BUILD_ASSERT(sizeof(TLS_PSK) - 1 <= CONFIG_MBEDTLS_PSK_MAX_LEN,
 #define PSK_MAX_LEN		64
 #endif
 
-#define PSK_TAG			1
-
 #if defined(CONFIG_GOLIOTH_SYSTEM_SETTINGS) &&	\
 	defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
 static void golioth_settings_check_credentials(void);
@@ -71,7 +69,7 @@ static uint8_t rx_buffer[RX_BUFFER_SIZE];
 static struct zsock_pollfd fds[NUM_POLLFDS];
 
 static sec_tag_t sec_tag_list[] = {
-	PSK_TAG,
+	CONFIG_GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG,
 };
 
 enum {
@@ -153,19 +151,19 @@ static int init_tls(void)
 		return err;
 	}
 
-	err = tls_credential_add(PSK_TAG,
-				TLS_CREDENTIAL_PSK,
-				TLS_PSK,
-				sizeof(TLS_PSK) - 1);
+	err = tls_credential_add(CONFIG_GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG,
+				 TLS_CREDENTIAL_PSK,
+				 TLS_PSK,
+				 sizeof(TLS_PSK) - 1);
 	if (err < 0) {
 		LOG_ERR("Failed to register PSK: %d", err);
 		return err;
 	}
 
-	err = tls_credential_add(PSK_TAG,
-				TLS_CREDENTIAL_PSK_ID,
-				TLS_PSK_ID,
-				sizeof(TLS_PSK_ID) - 1);
+	err = tls_credential_add(CONFIG_GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG,
+				 TLS_CREDENTIAL_PSK_ID,
+				 TLS_PSK_ID,
+				 sizeof(TLS_PSK_ID) - 1);
 	if (err < 0) {
 		LOG_ERR("Failed to register PSK ID: %d", err);
 		return err;
@@ -485,7 +483,7 @@ static int golioth_settings_set(const char *name, size_t len_rd,
 	}
 
 	if (IS_ENABLED(CONFIG_SETTINGS_RUNTIME)) {
-		err = tls_credential_delete(PSK_TAG, type);
+		err = tls_credential_delete(CONFIG_GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG, type);
 		if (err && err != -ENOENT) {
 			LOG_ERR("Failed to delete cred %s: %d",
 				log_strdup(name), err);
@@ -521,7 +519,8 @@ static int golioth_settings_set(const char *name, size_t len_rd,
 		break;
 	}
 
-	err = tls_credential_add(PSK_TAG, type, value, *value_len);
+	err = tls_credential_add(CONFIG_GOLIOTH_SYSTEM_CLIENT_CREDENTIALS_TAG, type,
+				 value, *value_len);
 	if (err) {
 		LOG_ERR("Failed to add cred %s: %d", log_strdup(name), err);
 		return err;


### PR DESCRIPTION
So far 1 was used as TLS credentials tag. This was copy-pasted from Zephyr
TLS sample code and most likely would conflict with user code trying to
maintain second TLS connection together with connection with Golioth cloud.

Add configurable option, so that application can decide which tag to use
when managing connection by Golioth system client. Also choose a random
number, so that chances of conflict are minimized.