### PR TITLE
settings: fix ESP32 WiFi credentials

### DIFF
--- a/samples/settings/Kconfig
+++ b/samples/settings/Kconfig
@@ -3,6 +3,16 @@
 
 mainmenu "Golioth application options"
 
+if WIFI_ESP32
+
+config ESP32_WIFI_SSID
+	default GOLIOTH_SAMPLE_WIFI_SSID
+
+config ESP32_WIFI_PASSWORD
+	default GOLIOTH_SAMPLE_WIFI_PSK
+
+endif # WIFI_ESP32
+
 if DNS_RESOLVER
 
 config DNS_SERVER_IP_ADDRESSES

--- a/samples/settings/README.rst
+++ b/samples/settings/README.rst
@@ -106,8 +106,8 @@ by adding these lines to configuration file (e.g. ``prj.conf`` or
 
 .. code-block:: cfg
 
-   CONFIG_ESP32_WIFI_SSID="my-wifi"
-   CONFIG_ESP32_WIFI_PSK="my-psk"
+   CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
+   CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
 
 On your host computer open a terminal window, locate the source code of this
 sample application (i.e., ``samples/settings``) and type:


### PR DESCRIPTION
The instructions in the current samples/settings README
are incorrect for ESP32. They indicate that the user should
set CONFIG_ESP32_WIFI_SSID and CONFIG_ESP32_WIFI_PSK, but
when setting these, the project will not build.

To fix, use CONFIG_GOLIOTH_SAMPLE_WIFI_SSID/PSK instead,
similar to the other samples.

Signed-off-by: Nick Miller <nick@golioth.io>