### PR TITLE
golioth: {rpc,settings}: forward declare qcbor typedefs and drop header use

### DIFF
--- a/include/net/golioth/rpc.h
+++ b/include/net/golioth/rpc.h
@@ -7,10 +7,14 @@
 #ifndef GOLIOTH_INCLUDE_NET_GOLIOTH_RPC_H_
 #define GOLIOTH_INCLUDE_NET_GOLIOTH_RPC_H_
 
-#include <qcbor/qcbor.h>
-#include <qcbor/qcbor_spiffy_decode.h>
 #include <net/coap.h>
 #include <stdint.h>
+
+struct _QCBOREncodeContext;
+struct _QCBOREncodeContext;
+
+typedef struct _QCBORDecodeContext QCBORDecodeContext;
+typedef struct _QCBOREncodeContext QCBOREncodeContext;
 
 /**
  * @defgroup golioth_rpc Golioth Remote Procedure Call

--- a/include/net/golioth/settings.h
+++ b/include/net/golioth/settings.h
@@ -7,8 +7,6 @@
 #ifndef GOLIOTH_INCLUDE_NET_GOLIOTH_SETTINGS_H_
 #define GOLIOTH_INCLUDE_NET_GOLIOTH_SETTINGS_H_
 
-#include <qcbor/qcbor.h>
-#include <qcbor/qcbor_spiffy_decode.h>
 #include <net/coap.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Currently both RPC and Settings headers pull QCBOR headers. This means that
QCBOR module needs to be added as Zephyr module (e.g. by specifying in west
manifest when west is used for repository management). This is true even
when neither RPC nor Settings are actually used (like it is the case for
simplest 'hello' sample).

Remove QCBOR header inclusion and forward declare QCBORDecodeContext and
QCBOREncodeContext types instead. As pointers to those types are used in
the Golioth RPC/Settings APIs, then there is no need to have full
information about those types as long as their values are not referenced.

This solves build errors of samples that do not use RPC and Settings and do
not enable CONFIG_QCBOR.
