### PR TITLE
settings: allow label type as byte or text string

### DIFF
--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -148,7 +148,8 @@ static int on_setting(const struct coap_packet *response,
 		char key[GOLIOTH_SETTINGS_MAX_NAME_LEN + 1] = {};
 
 		/* Copy setting label/name and ensure it's NULL-terminated */
-		assert(decoded_item.uLabelType == QCBOR_TYPE_BYTE_STRING);
+		assert((decoded_item.uLabelType == QCBOR_TYPE_BYTE_STRING) ||
+		       (decoded_item.uLabelType == QCBOR_TYPE_TEXT_STRING));
 		memcpy(key,
 		       label.ptr,
 		       MIN(GOLIOTH_SETTINGS_MAX_NAME_LEN, label.len));


### PR DESCRIPTION
The prior assertion assumed the setting label was
always type QCBOR_TYPE_BYTE_STRING.

However, when testing settings, there was a board crash
due to detecting the label as type QCBOR_TYPE_TEXT_STRING.

Updating the assertion to allow either type for the label.

Signed-off-by: Nick Miller <nick@golioth.io>