### PR TITLE
samples: remove 'net' tag from all sample.yaml

### DIFF
--- a/samples/dfu/sample.yaml
+++ b/samples/dfu/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net socket
+  tags: golioth socket
 tests:
   sample.golioth.dfu: {}

--- a/samples/hello/sample.yaml
+++ b/samples/hello/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net socket
+  tags: golioth socket
 tests:
   sample.golioth.hello: {}

--- a/samples/hello_sporadic/sample.yaml
+++ b/samples/hello_sporadic/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net socket
+  tags: golioth socket
 tests:
   sample.golioth.hello: {}

--- a/samples/lightdb/get/sample.yaml
+++ b/samples/lightdb/get/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth lightdb net socket
+  tags: golioth lightdb socket
 tests:
   sample.golioth.lightdb_get: {}

--- a/samples/lightdb/observe/sample.yaml
+++ b/samples/lightdb/observe/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth lightdb net socket
+  tags: golioth lightdb socket
 tests:
   sample.golioth.lightdb_observe: {}

--- a/samples/lightdb/set/sample.yaml
+++ b/samples/lightdb/set/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth lightdb net socket
+  tags: golioth lightdb socket
 tests:
   sample.golioth.lightdb_set: {}

--- a/samples/lightdb_led/sample.yaml
+++ b/samples/lightdb_led/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net socket
+  tags: golioth socket
 tests:
   sample.golioth.lightdb_led: {}

--- a/samples/lightdb_stream/sample.yaml
+++ b/samples/lightdb_stream/sample.yaml
@@ -8,6 +8,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net socket
+  tags: golioth socket
 tests:
   sample.golioth.lightdb_stream: {}

--- a/samples/logging/sample.yaml
+++ b/samples/logging/sample.yaml
@@ -8,7 +8,7 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth logger net socket
+  tags: golioth logger socket
 tests:
   sample.golioth.logging.v1: {}
   sample.golioth.logging.v2:

--- a/samples/settings/sample.yaml
+++ b/samples/settings/sample.yaml
@@ -9,6 +9,6 @@ common:
     nrf52840dk_nrf52840
     nrf9160dk_nrf9160_ns
     qemu_x86
-  tags: golioth net settings socket
+  tags: golioth settings socket
 tests:
   sample.golioth.settings: {}


### PR DESCRIPTION
twister filters out ESP32 platforms from all samples, because they have
'net' tag specified, which is excluded in 'esp32' board definition in
Zephyr. This is the case after ESP32 platform got support in Zephyr SDK.

Fixes: 12b34cc201e0 ("bump Zephyr and NCS to tip of main")