### PR TITLE
golioth_settings: add int64 support

### DIFF
--- a/include/net/golioth/settings.h
+++ b/include/net/golioth/settings.h
@@ -70,6 +70,7 @@ enum golioth_settings_value_type {
 	GOLIOTH_SETTINGS_VALUE_TYPE_BOOL,
 	GOLIOTH_SETTINGS_VALUE_TYPE_FLOAT,
 	GOLIOTH_SETTINGS_VALUE_TYPE_STRING,
+	GOLIOTH_SETTINGS_VALUE_TYPE_INT64,
 };
 
 /**
@@ -86,6 +87,7 @@ struct golioth_settings_value {
 			const char *ptr; /* not NULL-terminated */
 			size_t len;
 		} string;
+		int64_t i64;
 	};
 };
 

--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -159,16 +159,10 @@ static int on_setting(const struct coap_packet *response,
 		bool data_type_valid = true;
 		struct golioth_settings_value value = {};
 
-		/*
-		 * TODO - Add support for decoding integers
-		 *
-		 * Currently, the Golioth server encodes all numbers
-		 * as doubles, but the following ticket will add support for encoding
-		 * integers as integers (instead of double) in the payload:
-		 *
-		 * https://golioth.atlassian.net/browse/GB-346.
-		 */
-		if (data_type == QCBOR_TYPE_DOUBLE) {
+		if (data_type == QCBOR_TYPE_INT64) {
+			value.type = GOLIOTH_SETTINGS_VALUE_TYPE_INT64;
+			value.i64 = decoded_item.val.int64;
+		} else if (data_type == QCBOR_TYPE_DOUBLE) {
 			value.type = GOLIOTH_SETTINGS_VALUE_TYPE_FLOAT;
 			value.f = (float)decoded_item.val.dfnum;
 		} else if (data_type == QCBOR_TYPE_TRUE) {

--- a/samples/settings/src/main.c
+++ b/samples/settings/src/main.c
@@ -22,6 +22,8 @@ enum golioth_settings_status on_setting(
 {
 	LOG_DBG("Received setting: key = %s, type = %d", key, value->type);
 	if (strcmp(key, "LOOP_DELAY_S") == 0) {
+		/* TODO - change type to INT64 once backend support is merged to prod */
+
 		/* This setting is expected to be numeric, return an error if it's not */
 		if (value->type != GOLIOTH_SETTINGS_VALUE_TYPE_FLOAT) {
 			return GOLIOTH_SETTINGS_VALUE_FORMAT_NOT_VALID;


### PR DESCRIPTION
The backend now supports CBOR encoding of integers.
Add additional type for int64 settings.

CBOR-encoded integers only use as many bytes as
necessary, but we will treat them all as uint64_t
after decoding.

Note: The Golioth backend does not support
integers greater than INT64_MAX (9223372036854775807),
so there's no need to support a uint64 type.

Signed-off-by: Nick Miller <nick@golioth.io>

### Testing

Tested with local backend and local UI on branches with CBOR-encoding fixes:

Backend: https://github.com/golioth/golioth/pull/168
UI: https://github.com/golioth/golioth-web/pull/49