### PR TITLE
RPC and Settings Build Fixes

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -41,6 +41,7 @@ config GOLIOTH_FW
 
 config GOLIOTH_RPC
 	bool "Remote Procedure Call"
+	select QCBOR
 	help
 	  Enable Golioth Remote Procedure Call feature.
 
@@ -54,6 +55,7 @@ config GOLIOTH_RPC_MAX_NUM_METHODS
 
 config GOLIOTH_SETTINGS
 	bool "Settings cloud service"
+	select QCBOR
 	help
 	  Enable Golioth Settings feature. Not to be confused
 	  with Zephyr's own Settings subsystem.

--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -218,9 +218,9 @@ static int golioth_rpc_observe(struct golioth_client *client)
 	return golioth_send_coap(client, &packet);
 }
 
-void on_message(struct golioth_client *client,
-		struct coap_packet *rx,
-		void *user_arg)
+static void on_message(struct golioth_client *client,
+		       struct coap_packet *rx,
+		       void *user_arg)
 {
 	k_mutex_lock(&client->rpc_mutex, K_FOREVER);
 	coap_response_received(rx, NULL, &client->rpc.observe_reply, 1);

--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -247,9 +247,9 @@ static int golioth_settings_observe(struct golioth_client *client)
 	return golioth_send_coap(client, &packet);
 }
 
-void on_message(struct golioth_client *client,
-		struct coap_packet *rx,
-		void *user_arg)
+static void on_message(struct golioth_client *client,
+		       struct coap_packet *rx,
+		       void *user_arg)
 {
 	coap_response_received(rx, NULL, &client->settings.observe_reply, 1);
 }

--- a/samples/rpc/src/main.c
+++ b/samples/rpc/src/main.c
@@ -11,6 +11,8 @@ LOG_MODULE_REGISTER(golioth_rpc, LOG_LEVEL_DBG);
 #include <net/golioth/system_client.h>
 #include <net/golioth/rpc.h>
 #include <samples/common/wifi.h>
+#include <qcbor/qcbor.h>
+#include <qcbor/qcbor_spiffy_decode.h>
 #include <assert.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();


### PR DESCRIPTION
There were build failures in samples when both RPC and Settings were enabled, so these commits fix those issues.