### PR TITLE
settings: option to persist Golioth settings

### DIFF
--- a/include/net/golioth/settings.h
+++ b/include/net/golioth/settings.h
@@ -32,6 +32,14 @@
  * 4. For each setting, this library calls the user-registered callback.
  * 5. This library reports status of applying settings to cloud.
  *
+ * If the user's callback returns GOLIOTH_SETTINGS_SUCCESS, then the
+ * setting is automatically stored to persistent flash via the Zephyr
+ * Settings subsystem if CONFIG_GOLIOTH_SETTINGS_PERSIST is 'y'.
+ * Storing the setting in flash can be useful for applications that
+ * need the setting before the device connects to Golioth.
+ * For this use-case, it's the user's responsibility to retrieve
+ * the setting from the Zephyr Settings subsystem, if desired.
+ *
  * This library is responsible for interfacing with the cloud
  * and has no knowledge of the specific settings.
  * @{

--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -104,6 +104,14 @@ config GOLIOTH_SETTINGS
 	  Enable Golioth Settings feature. Not to be confused
 	  with Zephyr's own Settings subsystem.
 
+config GOLIOTH_SETTINGS_PERSIST
+	bool "Save Golioth settings to persistent storage"
+	depends on GOLIOTH_SETTINGS
+	default y
+	help
+	  Automatically save settings received from Golioth cloud to persistent
+	  storage via the Zephyr Settings subsystem.
+
 config GOLIOTH_FW_PACKAGE_NAME_MAX_LEN
 	int "Maximum length of package name"
 	default 32


### PR DESCRIPTION
### Main commit

Settings will be stored to persistent storage (via Zephyr's
Settings subsystem), but only if the user's settings
callback returns success, indicating the setting is
known and valid.

The intended use is for users that
need access to their settings before connecting to
Golioth. It's up to the user to retrieve the settings
out of the Zephyr Settings subsystem, if desired.

### Additional related commit

settings_shell: support to get nonprintable values 

If the setting is not a printable string, then "settings get"
will not display anything useful.

If the value contains nonprintable characters, we will
hex dump the value.