### PR TITLE
net/golioth: remove hexdump of tx packet

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -346,8 +346,6 @@ int golioth_send_coap(struct golioth_client *client, struct coap_packet *packet)
 {
 	int err;
 
-	LOG_HEXDUMP_DBG(packet->data, packet->offset, "TX CoAP");
-
 	err = golioth_send(client, packet->data, packet->offset, 0);
 	if (err) {
 		return err;


### PR DESCRIPTION
If CONFIG_LOG_GOLIOTH_LOG_LEVEL_DBG is set to 'y'
then the system will freeze at boot after a couple
of seconds (tested on nRF9160dk), which I suspect
is due to the hexdump of tx packets, because when
the hexdump is removed, the system boots normally.

Signed-off-by: Nick Miller <nick@golioth.io>