### PR TITLE
Content format cleanups and introduction of golioth_content_format

### DIFF
--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -297,7 +297,7 @@ int golioth_send_hello(struct golioth_client *client);
  * @retval <0 On failure
  */
 int golioth_lightdb_get(struct golioth_client *client, const uint8_t *path,
-			enum coap_content_format format,
+			enum golioth_content_format format,
 			struct coap_reply *reply, coap_reply_t reply_cb);
 
 /**
@@ -315,7 +315,7 @@ int golioth_lightdb_get(struct golioth_client *client, const uint8_t *path,
  * @retval <0 On failure
  */
 int golioth_lightdb_set(struct golioth_client *client, const uint8_t *path,
-			enum coap_content_format format,
+			enum golioth_content_format format,
 			uint8_t *data, uint16_t data_len);
 
 /**
@@ -347,7 +347,7 @@ int golioth_lightdb_delete(struct golioth_client *client, const uint8_t *path);
  * @retval <0 On failure
  */
 int golioth_lightdb_observe(struct golioth_client *client, const uint8_t *path,
-			    enum coap_content_format format,
+			    enum golioth_content_format format,
 			    struct coap_reply *reply, coap_reply_t reply_cb);
 
 /**

--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -31,6 +31,15 @@
 #define GOLIOTH_LIGHTDB_STREAM_PATH(x)	".s/" x
 
 /**
+ * @brief Set of Content-Format option values for Golioth APIs
+ */
+enum golioth_content_format {
+	GOLIOTH_CONTENT_FORMAT_APP_OCTET_STREAM = COAP_CONTENT_FORMAT_APP_OCTET_STREAM,
+	GOLIOTH_CONTENT_FORMAT_APP_JSON = COAP_CONTENT_FORMAT_APP_JSON,
+	GOLIOTH_CONTENT_FORMAT_APP_CBOR = COAP_CONTENT_FORMAT_APP_CBOR,
+};
+
+/**
  * @brief (D)TLS credentials of Golioth client.
  */
 struct golioth_tls {

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -428,7 +428,7 @@ int golioth_send_hello(struct golioth_client *client)
 }
 
 int golioth_lightdb_get(struct golioth_client *client, const uint8_t *path,
-			enum coap_content_format format,
+			enum golioth_content_format format,
 			struct coap_reply *reply, coap_reply_t reply_cb)
 {
 	struct coap_packet packet;
@@ -468,7 +468,7 @@ int golioth_lightdb_get(struct golioth_client *client, const uint8_t *path,
 }
 
 int golioth_lightdb_set(struct golioth_client *client, const uint8_t *path,
-			enum coap_content_format format,
+			enum golioth_content_format format,
 			uint8_t *data, uint16_t data_len)
 {
 	struct coap_packet packet;
@@ -553,7 +553,7 @@ static int golioth_coap_observe_init(struct coap_packet *packet,
 }
 
 int golioth_lightdb_observe(struct golioth_client *client, const uint8_t *path,
-			    enum coap_content_format format,
+			    enum golioth_content_format format,
 			    struct coap_reply *reply, coap_reply_t reply_cb)
 {
 	struct coap_packet packet;

--- a/samples/lightdb/get/src/main.c
+++ b/samples/lightdb/get/src/main.c
@@ -102,7 +102,7 @@ void main(void)
 			 */
 			err = golioth_lightdb_get(client,
 						  GOLIOTH_LIGHTDB_PATH("counter"),
-						  COAP_CONTENT_FORMAT_APP_JSON,
+						  GOLIOTH_CONTENT_FORMAT_APP_JSON,
 						  reply, reply_callback);
 			if (err) {
 				LOG_WRN("failed to get data from LightDB: %d", err);

--- a/samples/lightdb/observe/src/main.c
+++ b/samples/lightdb/observe/src/main.c
@@ -69,7 +69,7 @@ static void golioth_on_connect(struct golioth_client *client)
 	 */
 	err = golioth_lightdb_observe(client,
 				      GOLIOTH_LIGHTDB_PATH("counter"),
-				      COAP_CONTENT_FORMAT_APP_JSON,
+				      GOLIOTH_CONTENT_FORMAT_APP_JSON,
 				      observe_reply, on_update);
 
 	if (err) {

--- a/samples/lightdb/observe/src/main.c
+++ b/samples/lightdb/observe/src/main.c
@@ -69,7 +69,7 @@ static void golioth_on_connect(struct golioth_client *client)
 	 */
 	err = golioth_lightdb_observe(client,
 				      GOLIOTH_LIGHTDB_PATH("counter"),
-				      COAP_CONTENT_FORMAT_TEXT_PLAIN,
+				      COAP_CONTENT_FORMAT_APP_JSON,
 				      observe_reply, on_update);
 
 	if (err) {

--- a/samples/lightdb/set/src/main.c
+++ b/samples/lightdb/set/src/main.c
@@ -27,7 +27,7 @@ static void counter_set(int counter)
 
 	err = golioth_lightdb_set(client,
 				  GOLIOTH_LIGHTDB_PATH("counter"),
-				  COAP_CONTENT_FORMAT_TEXT_PLAIN,
+				  COAP_CONTENT_FORMAT_APP_JSON,
 				  sbuf, strlen(sbuf));
 	if (err) {
 		LOG_WRN("Failed to update counter: %d", err);

--- a/samples/lightdb/set/src/main.c
+++ b/samples/lightdb/set/src/main.c
@@ -27,7 +27,7 @@ static void counter_set(int counter)
 
 	err = golioth_lightdb_set(client,
 				  GOLIOTH_LIGHTDB_PATH("counter"),
-				  COAP_CONTENT_FORMAT_APP_JSON,
+				  GOLIOTH_CONTENT_FORMAT_APP_JSON,
 				  sbuf, strlen(sbuf));
 	if (err) {
 		LOG_WRN("Failed to update counter: %d", err);

--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -183,7 +183,7 @@ static void golioth_on_connect(struct golioth_client *client)
 	}
 
 	err = golioth_lightdb_observe(client, GOLIOTH_LIGHTDB_PATH("led"),
-				      COAP_CONTENT_FORMAT_APP_CBOR,
+				      GOLIOTH_CONTENT_FORMAT_APP_CBOR,
 				      observe_reply, golioth_led_handle);
 }
 

--- a/samples/lightdb_stream/src/main.c
+++ b/samples/lightdb_stream/src/main.c
@@ -96,7 +96,7 @@ void main(void)
 
 		err = golioth_lightdb_set(client,
 					  GOLIOTH_LIGHTDB_STREAM_PATH("temp"),
-					  COAP_CONTENT_FORMAT_APP_JSON,
+					  GOLIOTH_CONTENT_FORMAT_APP_JSON,
 					  str_temperature,
 					  strlen(str_temperature));
 		if (err) {

--- a/samples/lightdb_stream/src/main.c
+++ b/samples/lightdb_stream/src/main.c
@@ -96,7 +96,7 @@ void main(void)
 
 		err = golioth_lightdb_set(client,
 					  GOLIOTH_LIGHTDB_STREAM_PATH("temp"),
-					  COAP_CONTENT_FORMAT_TEXT_PLAIN,
+					  COAP_CONTENT_FORMAT_APP_JSON,
 					  str_temperature,
 					  strlen(str_temperature));
 		if (err) {


### PR DESCRIPTION
Remove use of `text/plain` content format in favor of `application/json`.

Introduce `enum golioth_content_format` and use it in public lightdb APIs. This is the first step in phasing out explicit use of CoAP in public (high-level) APIs.