### PR TITLE
samples: wait for valid connection before first request

### DIFF
--- a/samples/hello/src/main.c
+++ b/samples/hello/src/main.c
@@ -13,6 +13,13 @@ LOG_MODULE_REGISTER(golioth_hello, LOG_LEVEL_DBG);
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 
+static K_SEM_DEFINE(connected, 0, 1);
+
+static void golioth_on_connect(struct golioth_client *client)
+{
+	k_sem_give(&connected);
+}
+
 static void golioth_on_message(struct golioth_client *client,
 			       struct coap_packet *rx)
 {
@@ -40,8 +47,11 @@ void main(void)
 		wifi_connect();
 	}
 
+	client->on_connect = golioth_on_connect;
 	client->on_message = golioth_on_message;
 	golioth_system_client_start();
+
+	k_sem_take(&connected, K_FOREVER);
 
 	while (true) {
 		LOG_INF("Sending hello! %d", counter);

--- a/samples/hello_sporadic/src/main.c
+++ b/samples/hello_sporadic/src/main.c
@@ -13,11 +13,11 @@ LOG_MODULE_REGISTER(golioth_hello, LOG_LEVEL_DBG);
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 
-K_SEM_DEFINE(sys_client_conn_resolved, 0, 1);
+static K_SEM_DEFINE(connected, 0, 1);
 
 static void golioth_on_connect(struct golioth_client *client)
 {
-	k_sem_give(&sys_client_conn_resolved);
+	k_sem_give(&connected);
 }
 
 static void golioth_on_message(struct golioth_client *client,
@@ -53,7 +53,7 @@ void main(void)
 	while (true) {
 
 		golioth_system_client_start();
-		k_sem_take(&sys_client_conn_resolved, K_FOREVER);
+		k_sem_take(&connected, K_FOREVER);
 
 		LOG_INF("Sending hello! %d", counter);
 


### PR DESCRIPTION
Add semaphore to samples, which will be released after connecting to cloud. That way first request to Golioth cloud will likely succeed, giving a better user experience.