### PR TITLE
samples: dfu: call sys_reboot() from sysworkq

### DIFF
--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -21,6 +21,13 @@ LOG_MODULE_REGISTER(golioth_dfu, LOG_LEVEL_DBG);
 
 #define REBOOT_DELAY_SEC	1
 
+static void reboot_handler(struct k_work *work)
+{
+	sys_reboot(SYS_REBOOT_COLD);
+}
+
+K_WORK_DELAYABLE_DEFINE(reboot_work, reboot_handler);
+
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 
 static struct coap_reply coap_replies[4];
@@ -89,9 +96,7 @@ static int data_received(struct golioth_blockwise_download_ctx *ctx,
 		/* Synchronize logs */
 		LOG_PANIC();
 
-		k_sleep(K_SECONDS(REBOOT_DELAY_SEC));
-
-		sys_reboot(SYS_REBOOT_COLD);
+		k_work_schedule(&reboot_work, K_SECONDS(REBOOT_DELAY_SEC));
 	}
 
 	return 0;


### PR DESCRIPTION
So far sys_reboot() was called directly from CoAP reply callback after a
bit of delay. This was fine so far, as all packets sent to cloud with
golioth_fw_report_state() were sent synchronously (just once, without
waiting for reply or acknowledgement). This approach prevents any
communication with Golioth cloud, as connection thread (the one calling
data_received() callback) is blocked. This means that no packet (for
reporting firmware version) retransmission is possible (once it will be
implemented).

Get rid of k_sleep() call and schedule a work item that will be run from
system workqueue with proper delay. That way Golioth CoAP receive handler
is not blocked and communication with Golioth cloud can still happen,
leaving possibility for sending CoAP request from golioth_fw_report_state()
API by system client thread (just after finishing execution of
data_received() callback), instead of doing it synchronously (calling
send() on transport socket) directly in golioth_fw_report_state().