### PR TITLE
gitlab-ci: remove --board-root option

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,6 @@ twister-ncs:
   script:
     - >
       zephyr/scripts/twister
-      --board-root nrf/boards
       -p nrf9160dk_nrf9160_ns
       -o reports
       -T modules/lib/golioth


### PR DESCRIPTION
This option was introduced with commit 46484fbe6ce1 ("gitlab-ci: add
thingy91_nrf9160_ns tests with NCS"). Unfortunately this line was not
removed with removal of thingy91 board in commit 72b1bcf52778 ("limit
supported platforms to ESP32, nRF52840DK, nRF9160DK and QEMU_x86"), so do
it now.