### PR TITLE
bump Zephyr and NCS to tip of main

### DIFF
--- a/logging/Kconfig
+++ b/logging/Kconfig
@@ -23,10 +23,4 @@ config LOG_BACKEND_GOLIOTH_MAX_PACKET_SIZE
 	  Specified maximum buffer size used for sending log entry to Golioth
 	  cloud.
 
-config LOG_BACKEND_GOLIOTH_LOG_MSG2_COMPAT
-	bool
-	default y if ZEPHYR_NRF_MODULE
-	help
-	  Enable compatibility with log_msg2 APIs.
-
 endif # LOG_BACKEND_GOLIOTH

--- a/logging/log_backend_golioth.c
+++ b/logging/log_backend_golioth.c
@@ -25,22 +25,6 @@
 #define LOGS_URI_PATH		"logs"
 #define CBOR_SPACE_RESERVED	8
 
-/*
- * Compatibility macros for NCS, which does not have commit:
- * 9833ca61c990 ("logging: Removing v2 suffix from logging names")
- * in Zephyr fork yet.
- */
-#ifdef CONFIG_LOG_BACKEND_GOLIOTH_LOG_MSG2_COMPAT
-#define log_msg			log_msg2
-#define log_msg_get_source	log_msg2_get_source
-#define log_msg_get_domain	log_msg2_get_domain
-#define log_msg_get_level	log_msg2_get_level
-#define log_msg_get_timestamp	log_msg2_get_timestamp
-#define log_msg_get_package	log_msg2_get_package
-#define log_msg_get_data	log_msg2_get_data
-#define log_msg_generic		log_msg2_generic
-#endif
-
 struct golioth_cbor_ctx {
 	QCBOREncodeContext encode_ctx;
 	UsefulBuf encode_bufc;

--- a/samples/dfu/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/dfu/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/hello/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/hello/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/hello_sporadic/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/hello_sporadic/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/lightdb/get/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/get/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/lightdb/observe/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/observe/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/lightdb/set/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb/set/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/lightdb_led/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb_led/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/lightdb_stream/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/lightdb_stream/boards/nrf52840dk_nrf52840.overlay
@@ -31,7 +31,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/logging/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/logging/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/rpc/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/rpc/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/settings/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/settings/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/test/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/test/boards/nrf52840dk_nrf52840.overlay
@@ -25,7 +25,6 @@
 
 	esp_wifi: esp-wifi {
 		compatible = "espressif,esp-at";
-		label = "esp-wifi";
 		power-gpios = <&gpio1 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
 		status = "okay";
 	};

--- a/samples/test/src/main.c
+++ b/samples/test/src/main.c
@@ -7,12 +7,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(test, LOG_LEVEL_DBG);
 
-/* Make it compatible with twister running from NCS, which uses older Zephyr version */
-#ifdef CONFIG_LEGACY_INCLUDE_PATH
-#include <ztest.h>
-#else
 #include <zephyr/ztest.h>
-#endif
 
 #include <net/golioth/system_client.h>
 #include <samples/common/wifi.h>

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: 728e1b94c1ef225db4a9991240bbf5c0753a413d
+      revision: a897e619b5ac15bb27f47affd4d42c6cf8e1f49f
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: c2c467a6ffd2f22b12de82569494342663fa41ca
+      revision: 096fc3b82644c41a2b0a17854009cdb64ad7563c
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import:


### PR DESCRIPTION
NCS upmerged Zephyr fork to much more recent version. This allows to drop
compatibility workarounds like CONFIG_LOG_BACKEND_GOLIOTH_LOG_MSG2_COMPAT
Kconfig option and rely on zephyr/ include path for ZTEST API.

Update Zephyr revision as well, to rely on similar codebase with both
vanilla Zephyr and with NCS.