### PR TITLE
samples: lightdb_led: bring back "LED <num> -> <value>" info log

### DIFF
--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -153,11 +153,6 @@ This is the output from the serial console:
    [00:00:00.020,000] <inf> golioth_lightdb: Golioth client initialized
    [00:00:00.020,000] <inf> golioth_lightdb: Starting connect
    [00:00:00.040,000] <inf> golioth_lightdb: Client connected!
-   [00:00:00.040,000] <dbg> golioth_lightdb: Payload
-                                             a1 63 6d 73 67 62 4f 4b                          |.cmsgbOK
-   [00:00:00.040,000] <wrn> golioth_lightdb: Map key is not boolean
-   [00:00:00.040,000] <dbg> golioth_lightdb: Payload
-                                             a4 61 31 f4 61 32 f5 61  33 f5 61 30 f5          |.a1.a2.a 3.a0.
    [00:00:00.040,000] <inf> golioth_lightdb: LED 1 -> OFF
    [00:00:00.040,000] <inf> golioth_lightdb: LED 2 -> ON
    [00:00:00.040,000] <inf> golioth_lightdb: LED 3 -> ON
@@ -186,8 +181,6 @@ This request should result in following serial console output:
 
 .. code-block:: console
 
-   [00:00:04.050,000] <dbg> golioth_lightdb: Payload
-                                             a4 61 33 f5 61 30 f5 61  31 f4 61 32 f5          |.a3.a0.a 1.a2.
    [00:00:04.050,000] <inf> golioth_lightdb: LED 3 -> ON
    [00:00:04.050,000] <inf> golioth_lightdb: LED 0 -> ON
    [00:00:04.050,000] <inf> golioth_lightdb: LED 1 -> OFF

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -158,10 +158,10 @@ This is the output from the serial console:
    [00:00:00.040,000] <wrn> golioth_lightdb: Map key is not boolean
    [00:00:00.040,000] <dbg> golioth_lightdb: Payload
                                              a4 61 31 f4 61 32 f5 61  33 f5 61 30 f5          |.a1.a2.a 3.a0.
-   [00:00:00.040,000] <inf> golioth_lightdb: LED 1 -> 0
-   [00:00:00.040,000] <inf> golioth_lightdb: LED 2 -> 1
-   [00:00:00.040,000] <inf> golioth_lightdb: LED 3 -> 1
-   [00:00:00.040,000] <inf> golioth_lightdb: LED 0 -> 1
+   [00:00:00.040,000] <inf> golioth_lightdb: LED 1 -> OFF
+   [00:00:00.040,000] <inf> golioth_lightdb: LED 2 -> ON
+   [00:00:00.040,000] <inf> golioth_lightdb: LED 3 -> ON
+   [00:00:00.040,000] <inf> golioth_lightdb: LED 0 -> ON
 
 Monitor counter value
 =====================
@@ -188,10 +188,10 @@ This request should result in following serial console output:
 
    [00:00:04.050,000] <dbg> golioth_lightdb: Payload
                                              a4 61 33 f5 61 30 f5 61  31 f4 61 32 f5          |.a3.a0.a 1.a2.
-   [00:00:04.050,000] <inf> golioth_lightdb: LED 3 -> 1
-   [00:00:04.050,000] <inf> golioth_lightdb: LED 0 -> 1
-   [00:00:04.050,000] <inf> golioth_lightdb: LED 1 -> 0
-   [00:00:04.050,000] <inf> golioth_lightdb: LED 2 -> 1
+   [00:00:04.050,000] <inf> golioth_lightdb: LED 3 -> ON
+   [00:00:04.050,000] <inf> golioth_lightdb: LED 0 -> ON
+   [00:00:04.050,000] <inf> golioth_lightdb: LED 1 -> OFF
+   [00:00:04.050,000] <inf> golioth_lightdb: LED 2 -> ON
 
 Additionally board LEDs will be changed, if they are configured in device-tree
 as:

--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -74,6 +74,7 @@ static int golioth_led_handle(const struct coap_packet *response,
 	uint16_t payload_len;
 	QCBORError qerr;
 	char name[5];
+	bool value;
 
 	payload.ptr = coap_packet_get_payload(response, &payload_len);
 	payload.len = payload_len;
@@ -148,11 +149,15 @@ static int golioth_led_handle(const struct coap_packet *response,
 		memcpy(name, decoded_item.label.string.ptr, decoded_item.label.string.len);
 		name[decoded_item.label.string.len] = '\0';
 
+		value = (decoded_item.uDataType == QCBOR_TYPE_TRUE);
+
+		LOG_INF("LED %s -> %d", name, (int) value);
+
 		/*
 		 * Switch on/off requested LED based on label (LED name/id) and
 		 * value (requested LED state).
 		 */
-		golioth_led_set_by_name(name, decoded_item.uDataType == QCBOR_TYPE_TRUE);
+		golioth_led_set_by_name(name, value);
 	}
 
 	QCBORDecode_ExitMap(&decode_ctx);

--- a/samples/lightdb_led/src/main.c
+++ b/samples/lightdb_led/src/main.c
@@ -151,7 +151,7 @@ static int golioth_led_handle(const struct coap_packet *response,
 
 		value = (decoded_item.uDataType == QCBOR_TYPE_TRUE);
 
-		LOG_INF("LED %s -> %d", name, (int) value);
+		LOG_INF("LED %s -> %s", name, value ? "ON" : "OFF");
 
 		/*
 		 * Switch on/off requested LED based on label (LED name/id) and


### PR DESCRIPTION
This message is mentioned as part of README.rst and is very useful for
verifying if LED values are received correctly. This is especially
important for qemu_x86.

This brings back behavior before commit f72c094fe1f3 ("samples:
lightdb_led: convert from TinyCBOR to QCBOR") was merged.