### PR TITLE
{rpc,settings}: use POSIX error codes instead of -1

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -583,7 +583,7 @@ int golioth_register_message_callback(struct golioth_client *client,
 {
 	if (client->num_message_callbacks >= GOLIOTH_MAX_NUM_MESSAGE_CALLBACKS) {
 		LOG_ERR("No more message callback registration slots");
-		return -1;
+		return -ENOBUFS;
 	}
 
 	struct golioth_message_callback_reg *new_reg =

--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -244,7 +244,7 @@ int golioth_rpc_register(struct golioth_client *client,
 	if (client->rpc.num_methods >= CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS) {
 		LOG_ERR("Unable to register, can't register more than %d methods",
 			CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS);
-		status = -1;
+		status = -ENOBUFS;
 		goto cleanup;
 	}
 

--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -264,7 +264,7 @@ int golioth_settings_register_callback(struct golioth_client *client,
 {
 	if (!callback) {
 		LOG_ERR("Callback must not be NULL");
-		return -1;
+		return -EINVAL;
 	}
 
 	/*


### PR DESCRIPTION
We should not return -1 directly. Instead, POSIX error code should be returned, so there is same developer experience for most APIs.