### PR TITLE
[CoAP rework] coap_req: introduce new helper module

### DIFF
--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -288,6 +288,18 @@ int golioth_register_message_callback(struct golioth_client *client,
 				      golioth_message_callback callback,
 				      void *user_arg);
 
+/**
+ * @brief Prepare for poll() system call on transport socket
+ *
+ * @param[in] client Client instance
+ * @param[in] now Timestamp in msec for current event loop (e.g. output of k_uptime_get())
+ * @param[out] fd File descriptor of transport socket (optional, can be NULL)
+ * @param[out] timeout Timeout till the next action needs to be taken, such as resending a packet
+ *                     (optional, can be NULL)
+ */
+void golioth_poll_prepare(struct golioth_client *client, int64_t now,
+			  int *fd, int64_t *timeout);
+
 /** @} */
 
 #endif /* GOLIOTH_INCLUDE_NET_GOLIOTH_H_ */

--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -79,6 +79,9 @@ struct golioth_client {
 	struct k_mutex lock;
 	int sock;
 
+	sys_dlist_t coap_reqs;
+	struct k_mutex coap_reqs_lock;
+
 	void (*on_connect)(struct golioth_client *client);
 	void (*on_message)(struct golioth_client *client, struct coap_packet *rx);
 

--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -82,6 +82,8 @@ struct golioth_client {
 	void (*on_connect)(struct golioth_client *client);
 	void (*on_message)(struct golioth_client *client, struct coap_packet *rx);
 
+	void (*wakeup)(struct golioth_client *client);
+
 	/* Storage for additional on_message callbacks */
 	struct golioth_message_callback_reg message_callbacks[GOLIOTH_MAX_NUM_MESSAGE_CALLBACKS];
 	size_t num_message_callbacks;

--- a/include/net/golioth/req.h
+++ b/include/net/golioth/req.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GOLIOTH_INCLUDE_NET_GOLIOTH_REQ_H_
+#define GOLIOTH_INCLUDE_NET_GOLIOTH_REQ_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @typedef golioth_get_next_cb_t
+ *
+ * @brief Callback function for requesting more data to be received.
+ */
+typedef int (*golioth_get_next_cb_t)(void *get_next_data, int status);
+
+/**
+ * @brief Information about response to user request
+ *
+ * Stores information about receive response, acknowledgment, error condition (e.g. timeout, error
+ * received from server).
+ *
+ * If @p err is <0, then request failed with error and just @p user_data stores valid information.
+ * If @p err is 0, then response was successfully received (either with data, or just an
+ * acknowledgment).
+ */
+struct golioth_req_rsp {
+	const uint8_t *data;
+	size_t len;
+	size_t off;
+
+	size_t total;
+
+	/* TODO: provide more user-friendly helper function */
+	golioth_get_next_cb_t get_next;
+	void *get_next_data;
+
+	void *user_data;
+
+	int err;
+};
+
+/**
+ * @typedef golioth_req_cb_t
+ *
+ * @brief User callback for handling valid response from server or error condition
+ */
+typedef int (*golioth_req_cb_t)(struct golioth_req_rsp *rsp);
+
+#endif /* GOLIOTH_INCLUDE_NET_GOLIOTH_REQ_H_ */

--- a/net/golioth/CMakeLists.txt
+++ b/net/golioth/CMakeLists.txt
@@ -1,4 +1,5 @@
 zephyr_library_sources_ifdef(CONFIG_GOLIOTH
+  coap_req.c
   coap_utils.c
   golioth.c
   golioth_utils.c

--- a/net/golioth/CMakeLists.txt
+++ b/net/golioth/CMakeLists.txt
@@ -1,6 +1,7 @@
 zephyr_library_sources_ifdef(CONFIG_GOLIOTH
   coap_utils.c
   golioth.c
+  golioth_utils.c
   lightdb.c
 )
 zephyr_library_sources_ifdef(CONFIG_GOLIOTH_FW fw.c)

--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -1,0 +1,635 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(golioth);
+
+#include <stdlib.h>
+
+#include <zephyr/random/rand32.h>
+
+#include "coap_req.h"
+#include "coap_utils.h"
+#include "golioth_utils.h"
+
+#define COAP_RESPONSE_CODE_CLASS(code)	((code) >> 5)
+
+static int golioth_coap_req_send(struct golioth_coap_req *req)
+{
+	return golioth_send_coap(req->client, &req->request);
+}
+
+static void golioth_coap_pending_init(struct golioth_coap_pending *pending,
+				      uint8_t retries)
+{
+	pending->t0 = k_uptime_get_32();
+	pending->timeout = 0;
+	pending->retries = retries;
+}
+
+static void __golioth_coap_req_submit(struct golioth_coap_req *req)
+{
+	struct golioth_client *client = req->client;
+
+	sys_dlist_append(&client->coap_reqs, &req->node);
+}
+
+static void golioth_coap_req_submit(struct golioth_coap_req *req)
+{
+	struct golioth_client *client = req->client;
+
+	k_mutex_lock(&client->coap_reqs_lock, K_FOREVER);
+	__golioth_coap_req_submit(req);
+	k_mutex_unlock(&client->coap_reqs_lock);
+}
+
+static void golioth_coap_req_cancel(struct golioth_coap_req *req)
+{
+	sys_dlist_remove(&req->node);
+}
+
+static void golioth_coap_req_cancel_and_free(struct golioth_coap_req *req)
+{
+	LOG_DBG("cancel and free req %p data %p", req, req->request.data);
+
+	golioth_coap_req_cancel(req);
+	free(req->request.data);
+	free(req);
+}
+
+static int golioth_coap_code_to_posix(uint8_t code)
+{
+	switch (COAP_RESPONSE_CODE_CLASS(code)) {
+	case 2:
+		return 0;
+	case 4:
+		switch (code) {
+		case COAP_RESPONSE_CODE_BAD_REQUEST:
+			return -EFAULT;
+		case COAP_RESPONSE_CODE_UNAUTHORIZED:
+			return -EACCES;
+		case COAP_RESPONSE_CODE_BAD_OPTION:
+			return -EINVAL;
+		case COAP_RESPONSE_CODE_FORBIDDEN:
+			return -EACCES;
+		case COAP_RESPONSE_CODE_NOT_FOUND:
+			return -ENOENT;
+		case COAP_RESPONSE_CODE_NOT_ALLOWED:
+			return -EACCES;
+		case COAP_RESPONSE_CODE_NOT_ACCEPTABLE:
+			return -EACCES;
+		case COAP_RESPONSE_CODE_INCOMPLETE:
+			return -EINVAL;
+		case COAP_RESPONSE_CODE_CONFLICT:
+			return -EBUSY;
+		case COAP_RESPONSE_CODE_PRECONDITION_FAILED:
+			return -EACCES;
+		case COAP_RESPONSE_CODE_REQUEST_TOO_LARGE:
+			return -E2BIG;
+		case COAP_RESPONSE_CODE_UNSUPPORTED_CONTENT_FORMAT:
+			return -ENOTSUP;
+		case COAP_RESPONSE_CODE_UNPROCESSABLE_ENTITY:
+			return -EBADMSG;
+		case COAP_RESPONSE_CODE_TOO_MANY_REQUESTS:
+			return -EBUSY;
+		}
+		__fallthrough;
+	case 5:
+		return -EBADMSG;
+	default:
+		LOG_ERR("Unknown CoAP response code class (%u)",
+			(unsigned int)COAP_RESPONSE_CODE_CLASS(code));
+		return -EBADMSG;
+	}
+}
+
+static int golioth_coap_req_append_block2_option(struct golioth_coap_req *req)
+{
+	if (req->request_wo_block2.offset) {
+		/*
+		 * Block2 was already appended once, so just copy state before
+		 * it was done.
+		 */
+		req->request = req->request_wo_block2;
+	} else {
+		/*
+		 * Block2 is about to be appeneded for the first time, so
+		 * remember coap_packet state before adding this option.
+		 */
+		req->request_wo_block2 = req->request;
+	}
+
+	return coap_append_block2_option(&req->request, &req->block_ctx);
+}
+
+static int golioth_coap_req_next_block(void *data, int status)
+{
+	struct golioth_coap_req *req = data;
+	uint16_t next_id = coap_next_id();
+	int err;
+
+	if (status) {
+		LOG_WRN("Handle non-zero (%d) status", status);
+	}
+
+	if (req->is_observe) {
+		struct golioth_req_rsp rsp = {
+			.user_data = req->user_data,
+			.err = -ENOTSUP,
+		};
+
+		(void)req->cb(&rsp);
+
+		return 0;
+	}
+
+	coap_packet_set_id(&req->request, next_id);
+
+	err = golioth_coap_req_append_block2_option(req);
+	if (err) {
+		return err;
+	}
+
+	golioth_coap_pending_init(&req->pending, 3);
+
+	return 0;
+}
+
+/* Reordering according to RFC7641 section 3.4 but without timestamp comparison */
+static inline bool is_newer(int v1, int v2)
+{
+	return (v1 < v2 && v2 - v1 < (1 << 23)) ||
+		(v1 > v2 && v1 - v2 > (1 << 23));
+}
+
+static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
+					  const struct coap_packet *response)
+{
+	uint16_t payload_len;
+	uint8_t code;
+	const uint8_t *payload;
+	int block2;
+	int err;
+
+	code = coap_header_get_code(response);
+
+	LOG_DBG("CoAP response code: 0x%x (class %u detail %u)",
+		(unsigned int)code, (unsigned int)(code >> 5), (unsigned int)(code & 0x1f));
+
+	err = golioth_coap_code_to_posix(code);
+	if (err) {
+		struct golioth_req_rsp rsp = {
+			.user_data = req->user_data,
+			.err = err,
+		};
+
+		(void)req->cb(&rsp);
+
+		LOG_INF("cancel and free req: %p", req);
+
+		goto cancel_and_free;
+	}
+
+	payload = coap_packet_get_payload(response, &payload_len);
+
+	block2 = coap_get_option_int(response, COAP_OPTION_BLOCK2);
+	if (block2 != -ENOENT) {
+		size_t new_offset;
+		size_t cur_offset;
+
+		err = coap_update_from_block(response, &req->block_ctx);
+		if (err) {
+			struct golioth_req_rsp rsp = {
+				.user_data = req->user_data,
+				.err = -EBADMSG,
+			};
+
+			LOG_ERR("Failed to parse get response: %d", err);
+
+			(void)req->cb(&rsp);
+
+			err = -EBADMSG;
+			goto cancel_and_free;
+		}
+
+		cur_offset = req->block_ctx.current;
+
+		new_offset = coap_next_block_for_option(response, &req->block_ctx,
+							COAP_OPTION_BLOCK2);
+		if (new_offset < 0) {
+			struct golioth_req_rsp rsp = {
+				.user_data = req->user_data,
+				.err = -EBADMSG,
+			};
+
+			LOG_ERR("Failed to move to next block: %d", new_offset);
+
+			(void)req->cb(&rsp);
+
+			err = -EBADMSG;
+			goto cancel_and_free;
+		} else if (new_offset == 0) {
+			struct golioth_req_rsp rsp = {
+				.data = payload,
+				.len = payload_len,
+				.off = cur_offset,
+
+				.total = req->block_ctx.total_size,
+
+				.get_next = NULL,
+				.get_next_data = NULL,
+
+				.user_data = req->user_data,
+			};
+
+			LOG_DBG("Blockwise transfer is finished!");
+
+			(void)req->cb(&rsp);
+
+			goto cancel_and_free;
+		} else {
+			struct golioth_req_rsp rsp = {
+				.data = payload,
+				.len = payload_len,
+				.off = cur_offset,
+
+				.total = req->block_ctx.total_size,
+
+				.get_next = golioth_coap_req_next_block,
+				.get_next_data = req,
+
+				.user_data = req->user_data,
+
+				.err = req->is_observe ? -EMSGSIZE : 0,
+			};
+
+			err = req->cb(&rsp);
+			if (err) {
+				LOG_WRN("Received error (%d) from callback, cancelling", err);
+				goto cancel_and_free;
+			}
+
+			if (req->is_observe) {
+				LOG_ERR("TODO: blockwise observe is not supported");
+				err = -ENOTSUP;
+				goto cancel_and_free;
+			}
+
+			return 0;
+		}
+	} else {
+		struct golioth_req_rsp rsp = {
+			.data = payload,
+			.len = payload_len,
+			.off = 0,
+
+			/* Is it the same as 'req->block_ctx.total_size' ? */
+			.total = payload_len,
+
+			.get_next = NULL,
+			.get_next_data = NULL,
+
+			.user_data = req->user_data,
+		};
+
+		(void)req->cb(&rsp);
+
+		goto cancel_and_free;
+	}
+
+cancel_and_free:
+	if (req->is_observe && !err) {
+		req->is_pending = false;
+	} else {
+		golioth_coap_req_cancel_and_free(req);
+	}
+
+	return 0;
+}
+
+void golioth_coap_req_process_rx(struct golioth_client *client, const struct coap_packet *rx)
+{
+	struct golioth_coap_req *req;
+	uint8_t rx_token[COAP_TOKEN_MAX_LEN];
+	uint16_t rx_id;
+	uint8_t rx_tkl;
+
+	rx_id = coap_header_get_id(rx);
+	rx_tkl = coap_header_get_token(rx, rx_token);
+
+	k_mutex_lock(&client->coap_reqs_lock, K_FOREVER);
+
+	SYS_DLIST_FOR_EACH_CONTAINER(&client->coap_reqs, req, node) {
+		uint16_t req_id = coap_header_get_id(&req->request);
+		uint8_t req_token[COAP_TOKEN_MAX_LEN];
+		uint8_t req_tkl = coap_header_get_token(&req->request, req_token);
+		int age;
+
+		if (req_id == 0U && req_tkl == 0U) {
+			continue;
+		}
+
+		/* Piggybacked must match id when token is empty */
+		if (req_id != rx_id && rx_tkl == 0U) {
+			continue;
+		}
+
+		if (rx_tkl > 0 && memcmp(req_token, rx_token, rx_tkl)) {
+			continue;
+		}
+
+		age = coap_get_option_int(rx, COAP_OPTION_OBSERVE);
+		/* handle observed requests only if received in order */
+		if (age == -ENOENT || is_newer(req->reply.age, age)) {
+			req->reply.age = age;
+			golioth_coap_req_reply_handler(req, rx);
+		}
+
+		break;
+	}
+
+	k_mutex_unlock(&client->coap_reqs_lock);
+}
+
+static int golioth_coap_req_init(struct golioth_coap_req *req,
+				 struct golioth_client *client,
+				 enum coap_method method,
+				 enum coap_msgtype msg_type,
+				 uint8_t *buffer, size_t buffer_len,
+				 golioth_req_cb_t cb, void *user_data)
+{
+	int err;
+
+	err = coap_packet_init(&req->request, buffer, buffer_len,
+			       COAP_VERSION_1, msg_type,
+			       COAP_TOKEN_MAX_LEN, coap_next_token(),
+			       method, coap_next_id());
+	if (err) {
+		return err;
+	}
+
+	req->client = client;
+	req->cb = cb;
+	req->user_data = user_data;
+	req->request_wo_block2.offset = 0;
+	req->reply.age = 0;
+
+	coap_block_transfer_init(&req->block_ctx, golioth_estimated_coap_block_size(client), 0);
+
+	return 0;
+}
+
+int golioth_coap_req_schedule(struct golioth_coap_req *req)
+{
+	struct golioth_client *client = req->client;
+
+	golioth_coap_pending_init(&req->pending, 3);
+
+	golioth_coap_req_submit(req);
+
+	if (client->wakeup) {
+		client->wakeup(client);
+	}
+
+	return 0;
+}
+
+int golioth_coap_req_new(struct golioth_coap_req **req,
+			 struct golioth_client *client,
+			 enum coap_method method,
+			 enum coap_msgtype msg_type,
+			 size_t buffer_len,
+			 golioth_req_cb_t cb, void *user_data)
+{
+	uint8_t *buffer;
+	int err;
+
+	*req = calloc(1, sizeof(**req));
+	if (!(*req)) {
+		LOG_ERR("Failed to allocate request");
+		return -ENOMEM;
+	}
+
+	buffer = malloc(buffer_len);
+	if (!buffer) {
+		LOG_ERR("Failed to allocate packet buffer");
+		err = -ENOMEM;
+		goto free_req;
+	}
+
+	err = golioth_coap_req_init(*req, client, method, msg_type,
+				    buffer, buffer_len,
+				    cb, user_data);
+	if (err) {
+		LOG_ERR("Failed to initialize CoAP GET request: %d", err);
+		goto free_buffer;
+	}
+
+	return 0;
+
+free_buffer:
+	free(buffer);
+
+free_req:
+	free(*req);
+
+	return err;
+}
+
+void golioth_coap_req_free(struct golioth_coap_req *req)
+{
+	free(req->request.data); /* buffer */
+	free(req);
+}
+
+int golioth_coap_req_cb(struct golioth_client *client,
+			enum coap_method method,
+			const uint8_t **pathv,
+			enum golioth_content_format format,
+			const uint8_t *data, size_t data_len,
+			golioth_req_cb_t cb, void *user_data,
+			int flags)
+{
+	size_t path_len = coap_pathv_estimate_alloc_len(pathv);
+	struct golioth_coap_req *req;
+	int err;
+
+	err = golioth_coap_req_new(&req, client, method, COAP_TYPE_CON,
+				   GOLIOTH_COAP_MAX_NON_PAYLOAD_LEN + path_len + data_len,
+				   cb, user_data);
+	if (err) {
+		LOG_ERR("Failed to create new CoAP GET request: %d", err);
+		goto free_req;
+	}
+
+	if (method == COAP_METHOD_GET && (flags & GOLIOTH_COAP_REQ_OBSERVE)) {
+		req->is_observe = true;
+		req->is_pending = true;
+
+		err = coap_append_option_int(&req->request, COAP_OPTION_OBSERVE, 0 /* register */);
+		if (err) {
+			LOG_ERR("Unable add observe option");
+			goto free_req;
+		}
+	}
+
+	err = coap_packet_append_uri_path_from_pathv(&req->request, pathv);
+	if (err) {
+		LOG_ERR("Unable add uri path to packet");
+		goto free_req;
+	}
+
+	if (method != COAP_METHOD_GET && method != COAP_METHOD_DELETE) {
+		err = coap_append_option_int(&req->request, COAP_OPTION_CONTENT_FORMAT, format);
+		if (err) {
+			LOG_ERR("Unable add content format to packet");
+			goto free_req;
+		}
+	}
+
+	if (!(flags & GOLIOTH_COAP_REQ_NO_RESP_BODY)) {
+		err = coap_append_option_int(&req->request, COAP_OPTION_ACCEPT, format);
+		if (err) {
+			LOG_ERR("Unable add content format to packet");
+			goto free_req;
+		}
+	}
+
+	if (data && data_len) {
+		err = coap_packet_append_payload_marker(&req->request);
+		if (err) {
+			LOG_ERR("Unable add payload marker to packet");
+			goto free_req;
+		}
+
+		err = coap_packet_append_payload(&req->request, data, data_len);
+		if (err) {
+			LOG_ERR("Unable add payload to packet");
+			goto free_req;
+		}
+	}
+
+	return golioth_coap_req_schedule(req);
+
+free_req:
+	golioth_coap_req_free(req);
+
+	return err;
+}
+
+static uint32_t init_ack_timeout(void)
+{
+#if defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT)
+	const uint32_t max_ack = CONFIG_COAP_INIT_ACK_TIMEOUT_MS *
+				 CONFIG_COAP_ACK_RANDOM_PERCENT / 100;
+	const uint32_t min_ack = CONFIG_COAP_INIT_ACK_TIMEOUT_MS;
+
+	/* Randomly generated initial ACK timeout
+	 * ACK_TIMEOUT < INIT_ACK_TIMEOUT < ACK_TIMEOUT * ACK_RANDOM_FACTOR
+	 * Ref: https://tools.ietf.org/html/rfc7252#section-4.8
+	 */
+	return min_ack + (sys_rand32_get() % (max_ack - min_ack));
+#else
+	return CONFIG_COAP_INIT_ACK_TIMEOUT_MS;
+#endif /* defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT) */
+}
+
+static bool golioth_coap_pending_cycle(struct golioth_coap_pending *pending)
+{
+	if (pending->timeout == 0) {
+		/* Initial transmission. */
+		pending->timeout = init_ack_timeout();
+
+		return true;
+	}
+
+	if (pending->retries == 0) {
+		return false;
+	}
+
+	pending->t0 += pending->timeout;
+	pending->timeout = pending->timeout << 1;
+	pending->retries--;
+
+	return true;
+}
+
+static int64_t golioth_coap_req_poll_prepare(struct golioth_coap_req *req, uint32_t now)
+{
+	int64_t timeout;
+	bool send = false;
+	bool resend = (req->pending.timeout != 0);
+	int err;
+
+	while (true) {
+		timeout = (int32_t)(req->pending.t0 + req->pending.timeout) - (int32_t)now;
+
+		if (timeout > 0) {
+			/* Return timeout when packet still waits for response/ack */
+			break;
+		}
+
+		send = golioth_coap_pending_cycle(&req->pending);
+		if (!send) {
+			struct golioth_req_rsp rsp = {
+				.user_data = req->user_data,
+				.err = -ETIMEDOUT,
+			};
+
+			LOG_WRN("Packet %p (reply %p) was not replied to", req, &req->reply);
+
+			(void)req->cb(&rsp);
+
+			golioth_coap_req_cancel_and_free(req);
+
+			return INT64_MAX;
+		}
+	}
+
+	if (send) {
+		if (resend) {
+			LOG_WRN("Resending request %p (reply %p) (retries %d)",
+				req, &req->reply,
+				(int)req->pending.retries);
+		}
+
+		err = golioth_coap_req_send(req);
+		if (err) {
+			LOG_ERR("Send error: %d", err);
+		}
+	}
+
+	return timeout;
+}
+
+static int64_t __golioth_coap_reqs_poll_prepare(struct golioth_client *client, int64_t now)
+{
+	struct golioth_coap_req *req, *next;
+	int64_t min_timeout = INT64_MAX;
+
+	SYS_DLIST_FOR_EACH_CONTAINER_SAFE(&client->coap_reqs, req, next, node) {
+		if (req->is_observe && !req->is_pending) {
+			continue;
+		}
+
+		int64_t req_timeout = golioth_coap_req_poll_prepare(req, now);
+
+		min_timeout = MIN(min_timeout, req_timeout);
+	}
+
+	return min_timeout;
+}
+
+int64_t golioth_coap_reqs_poll_prepare(struct golioth_client *client, int64_t now)
+{
+	int64_t timeout;
+
+	k_mutex_lock(&client->coap_reqs_lock, K_FOREVER);
+	timeout = __golioth_coap_reqs_poll_prepare(client, now);
+	k_mutex_unlock(&client->coap_reqs_lock);
+
+	return timeout;
+}

--- a/net/golioth/coap_req.h
+++ b/net/golioth/coap_req.h
@@ -135,6 +135,33 @@ int golioth_coap_req_cb(struct golioth_client *client,
 			int flags);
 
 /**
+ * @brief Schedule CoAP request and synchronously wait for response
+ *
+ * Synchronous version of golioth_coap_req_cb(). It waits for response/timeout/error and returns
+ * status as return value.
+ *
+ * @param[in] client Client instance
+ * @param[in] method CoAP request method
+ * @param[in] pathv Array of CoAP path components
+ * @param[in] format Content type
+ * @param[in] data CoAP request payload (NULL if no payload should be appended)
+ * @param[in] data_len Length of CoAP request payload
+ * @param[in] cb Callback executed on response received, timeout or error
+ * @param[in] user_data User data passed to @p cb
+ * @param[in] flags Flags (@sa golioth_coap_req_flags)
+ *
+ * @retval 0 On success
+ * @retval <0 On failure
+ */
+int golioth_coap_req_sync(struct golioth_client *client,
+			  enum coap_method method,
+			  const uint8_t **pathv,
+			  enum golioth_content_format format,
+			  const uint8_t *data, size_t data_len,
+			  golioth_req_cb_t cb, void *user_data,
+			  int flags);
+
+/**
  * @brief Handle CoAP packets (re)transmission and timeout
  *
  * Handles timeout of the next CoAP request retransmission, in case it was not responded to. If

--- a/net/golioth/coap_req.h
+++ b/net/golioth/coap_req.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __NET_GOLIOTH_COAP_REQ_H__
+#define __NET_GOLIOTH_COAP_REQ_H__
+
+#include <net/golioth.h>
+#include <net/golioth/req.h>
+
+/**
+ *  @defgroup golioth_coap_req_flags CoAP request flags
+ *  @{
+ */
+
+/** CoAP request is an observation */
+#define GOLIOTH_COAP_REQ_OBSERVE		BIT(0)
+/** CoAP request does not expect response with payload */
+#define GOLIOTH_COAP_REQ_NO_RESP_BODY		BIT(1)
+
+/** @} */
+
+/**
+ * @brief Information about a request awaiting for an acknowledgment (ACK).
+ *
+ * @note Modeled after #coap_pending
+ */
+struct golioth_coap_pending {
+	uint32_t t0;
+	uint32_t timeout;
+	uint8_t retries;
+};
+
+/**
+ * @brief Stores information about pending reply of a request.
+ *
+ * @note Modeled after #coap_reply
+ */
+struct golioth_coap_reply {
+	int age;		/* needed for observations only */
+};
+
+/**
+ * @brief Information about pending CoAP request
+ */
+struct golioth_coap_req {
+	sys_dnode_t node;
+	struct coap_packet request;
+	struct coap_packet request_wo_block2;
+	struct coap_block_context block_ctx;
+	struct golioth_coap_reply reply;
+
+	struct golioth_coap_pending pending;
+	bool is_observe;
+	bool is_pending;
+
+	struct golioth_client *client;
+
+	golioth_req_cb_t cb;
+	void *user_data;
+};
+
+/**
+ * @brief Allocate and initialize new CoAP request
+ *
+ * Allocates new CoAP request, buffer for data (according to @p buffer_len) and initializes it, so
+ * it is ready to be filled in (e.g. with coap_packet_append_option()) and scheduled for sending
+ * with golioth_coap_req_schedule().
+ *
+ * @param[out] req CoAP request, allocated and initialized
+ * @param[in] client Client instance
+ * @param[in] method CoAP request method
+ * @param[in] msg_type CoAP message type
+ * @param[in] buffer_len Length of buffer for CoAP packet
+ * @param[in] cb Callback executed on response received, timeout or error
+ * @param[in] user_data User data passed to @p cb
+ *
+ * @retval 0 On success
+ * @retval <0 On failure
+ */
+int golioth_coap_req_new(struct golioth_coap_req **req,
+			 struct golioth_client *client,
+			 enum coap_method method,
+			 enum coap_msgtype msg_type,
+			 size_t buffer_len,
+			 golioth_req_cb_t cb, void *user_data);
+
+/**
+ * @brief Free CoAP request
+ *
+ * @param[in] req CoAP request to be freed
+ */
+void golioth_coap_req_free(struct golioth_coap_req *req);
+
+/**
+ * @brief Schedule CoAP request for sending
+ *
+ * Schedule CoAP request for sending and
+ *
+ * @param[in] req CoAP request to be scheduled for sending
+ *
+ * @retval 0 On success
+ * @retval <0 On failure
+ */
+int golioth_coap_req_schedule(struct golioth_coap_req *req);
+
+/**
+ * @brief Create and schedule CoAP request for sending
+ *
+ * This is a combination of golioth_coap_req_new() and golioth_coap_req_schedule() with most common
+ * CoAP options (controlled/selected by @p flags) and request body appended to allocated CoAP
+ * packet.
+ *
+ * @param[in] client Client instance
+ * @param[in] method CoAP request method
+ * @param[in] pathv Array of CoAP path components
+ * @param[in] format Content type
+ * @param[in] data CoAP request payload (NULL if no payload should be appended)
+ * @param[in] data_len Length of CoAP request payload
+ * @param[in] cb Callback executed on response received, timeout or error
+ * @param[in] user_data User data passed to @p cb
+ * @param[in] flags Flags (@sa golioth_coap_req_flags)
+ *
+ * @retval 0 On success
+ * @retval <0 On failure
+ */
+int golioth_coap_req_cb(struct golioth_client *client,
+			enum coap_method method,
+			const uint8_t **pathv,
+			enum golioth_content_format format,
+			const uint8_t *data, size_t data_len,
+			golioth_req_cb_t cb, void *user_data,
+			int flags);
+
+/**
+ * @brief Handle CoAP packets (re)transmission and timeout
+ *
+ * Handles timeout of the next CoAP request retransmission, in case it was not responded to. If
+ * maximum number of retries was reached, then request is dropped with notification using
+ * #golioth_coap_req_cb_t callback. Since all created requests are scheduled with timeout of 0, it
+ * means that this function also handles sending of the request for the first time.
+ *
+ * @param[in] req CoAP request
+ * @param[in] now Timestamp in msec of current event loop (usually output of k_uptime_get())
+ *
+ * @retval INT64_MAX Infinite timeout (in case request reached maximum retranmissions and was
+ *                   dropped)
+ * @retval <INT64_MAX Timeout in msec starting from @p now when next retransmission will happen (or
+ *                    when packet will be dropped due to reaching maximum number of
+ *                    retransmissions).
+ */
+int64_t golioth_coap_reqs_poll_prepare(struct golioth_client *client, int64_t now);
+
+/**
+ * @brief Process received CoAP packet
+ *
+ * Iterates through all pending CoAP requests and checks if received packet is a response to one of
+ * those requests. Calls #golioth_req_coap_cb_t callback in case of received response.
+ *
+ * @param[in] client Client instance
+ * @param[in] rx Received CoAP packet
+ */
+void golioth_coap_req_process_rx(struct golioth_client *client, const struct coap_packet *rx);
+
+#endif /* __NET_GOLIOTH_COAP_REQ_H__ */

--- a/net/golioth/coap_utils.h
+++ b/net/golioth/coap_utils.h
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct coap_packet;
+#include <zephyr/net/coap.h>
 
 /**
  * Check CoAP packet type based on raw data received.
@@ -20,6 +20,12 @@ struct coap_packet;
  * @retval 0 valid CoAP packet (to be parsed with)
  */
 int coap_data_check_rx_packet_type(uint8_t *data, size_t len);
+
+static inline void coap_packet_set_id(struct coap_packet *packet, uint16_t id)
+{
+	packet->data[2] = id >> 8;
+	packet->data[3] = id & 0xff;
+}
 
 int coap_packet_append_uri_path_from_string_range(struct coap_packet *packet,
 						  const char *begin, const char *end);

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "coap_utils.h"
+#include "golioth_utils.h"
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(golioth, CONFIG_GOLIOTH_LOG_LEVEL);
@@ -513,32 +514,12 @@ static int golioth_recv(struct golioth_client *client, uint8_t *data,
 	return ret;
 }
 
-static enum coap_block_size max_block_size_from_payload_len(uint16_t payload_len)
-{
-	enum coap_block_size block_size = COAP_BLOCK_16;
-
-	payload_len /= 16;
-
-	while (payload_len > 1 && block_size < COAP_BLOCK_1024) {
-		block_size++;
-		payload_len /= 2;
-	}
-
-	return block_size;
-}
-
-static enum coap_block_size
-golioth_estimated_block_size(struct golioth_client *client)
-{
-	return max_block_size_from_payload_len(client->rx_buffer_len);
-}
-
 void golioth_blockwise_download_init(struct golioth_client *client,
 				     struct golioth_blockwise_download_ctx *ctx)
 {
 	ctx->client = client;
 	coap_block_transfer_init(&ctx->block_ctx,
-				 golioth_estimated_block_size(client), 0);
+				 golioth_estimated_coap_block_size(client), 0);
 
 	sys_put_be32(sys_rand32_get(), &ctx->token[0]);
 	sys_put_be32(sys_rand32_get(), &ctx->token[4]);

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -593,3 +593,15 @@ int golioth_register_message_callback(struct golioth_client *client,
 
 	return 0;
 }
+
+void golioth_poll_prepare(struct golioth_client *client, int64_t now,
+			  int *fd, int64_t *timeout)
+{
+	if (fd) {
+		*fd = client->sock;
+	}
+
+	if (timeout) {
+		*timeout = INT64_MAX;
+	}
+}

--- a/net/golioth/golioth_utils.c
+++ b/net/golioth/golioth_utils.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021-2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "golioth_utils.h"
+
+static enum coap_block_size max_block_size_from_payload_len(uint16_t payload_len)
+{
+	enum coap_block_size block_size = COAP_BLOCK_16;
+
+	payload_len /= 16;
+
+	while (payload_len > 1 && block_size < COAP_BLOCK_1024) {
+		block_size++;
+		payload_len /= 2;
+	}
+
+	return block_size;
+}
+
+enum coap_block_size golioth_estimated_coap_block_size(struct golioth_client *client)
+{
+	return max_block_size_from_payload_len(client->rx_buffer_len);
+}

--- a/net/golioth/golioth_utils.h
+++ b/net/golioth/golioth_utils.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __NET_GOLIOTH_GOLIOTH_UTILS_H__
+#define __NET_GOLIOTH_GOLIOTH_UTILS_H__
+
+#include <net/golioth.h>
+
+enum coap_block_size golioth_estimated_coap_block_size(struct golioth_client *client);
+
+#endif /* __NET_GOLIOTH_GOLIOTH_UTILS_H__ */

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -325,6 +325,7 @@ static void golioth_system_client_main(void *arg1, void *arg2, void *arg3)
 	int timeout;
 	int64_t recv_expiry = 0;
 	int64_t ping_expiry = 0;
+	int64_t golioth_timeout;
 	eventfd_t eventfd_value;
 	int err;
 	int ret;
@@ -353,7 +354,11 @@ static void golioth_system_client_main(void *arg1, void *arg2, void *arg3)
 
 		timeout_occurred = false;
 
+		golioth_poll_prepare(client, k_uptime_get(), NULL, &golioth_timeout);
+
 		timeout = MIN(recv_expiry, ping_expiry) - k_uptime_get();
+		timeout = MIN(timeout, golioth_timeout);
+
 		if (timeout < 0) {
 			timeout = 0;
 		}

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -105,6 +105,11 @@ static inline void client_notify_timeout(void)
 	eventfd_write(fds[POLLFD_EVENT].fd, 1);
 }
 
+static void golioth_system_client_wakeup(struct golioth_client *client)
+{
+	eventfd_write(fds[POLLFD_EVENT].fd, 1);
+}
+
 static void eventfd_timeout_handle(struct k_work *work)
 {
 	client_notify_timeout();
@@ -232,6 +237,8 @@ static int client_initialize(struct golioth_client *client)
 
 	client->rx_buffer = rx_buffer;
 	client->rx_buffer_len = sizeof(rx_buffer);
+
+	client->wakeup = golioth_system_client_wakeup;
 
 	err = golioth_set_proto_coap_dtls(client, sec_tag_list,
 					  ARRAY_SIZE(sec_tag_list));


### PR DESCRIPTION
Introduce new helper module, which will handle most low-level CoAP specific
tasks like:

 * contructing CoAP packets for the most common use cases,
 * keeping track of pending (unacked) CoAP packets,
 * retransmitting packets with exponential backoff,
 * requesting wakeup from poll() system call, when new packet is to be
   transmitted or there is a retransmission of pending packet needed,
 * handling block-wise transfers (requesting next blocks of data, if
   response contains information about block number),
 * providing thread-safe APIs.

Add `golioth_prepare_poll()` function will allow to get file descriptor and next
timeout value, so those values can be passed to subsequent poll() system call. 
This is used by `system_client.c` implementation, but the idea is to split it into 
application specific custom "system client" implementation.

TODO:
- [x] DFU samples fails to build for ESP32 (DRAM overflow)
- [x] to be tested with nRF91 modem sockets, where wakeup might not work (due to no suport of waking up from `poll()`)
- [x] wrap offloaded sockets to allow poll() be interrupted (part of #298)