### PR TITLE
.github: enable workflows on every PR

### DIFF
--- a/.github/disabled_workflows/test_nrf9160dk.yml
+++ b/.github/disabled_workflows/test_nrf9160dk.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build_for_hw_test:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -2,7 +2,6 @@ name: checkpatch
 
 on:
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -2,7 +2,6 @@ name: gitlint
 
 on:
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,6 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/test_mimxrt1060.yml
+++ b/.github/workflows/test_mimxrt1060.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Removed the constraint "branches: [main]" so that CI workflows will run even for pull requests that are based on branches other than main.

Signed-off-by: Nick Miller <nick@golioth.io>