### PR TITLE
golioth: always default to port 5684

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -151,8 +151,7 @@ config GOLIOTH_SYSTEM_SERVER_HOST
 
 config GOLIOTH_SYSTEM_SERVER_PORT
 	int "Server Port"
-	default 5684 if NET_SOCKETS_SOCKOPT_TLS
-	default 5683
+	default 5684
 	help
 	  Defines port number of Golioth server.
 


### PR DESCRIPTION
Support for plaintext UDP has been removed with commit e316e566d6c2 ("net: golioth: drop support for plaintext/unsecure UDP"), so remove setting default UDP port to 5683.