### PR TITLE
fw: gracefully handle case when no releases were rolled out yet

### DIFF
--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -97,7 +97,14 @@ int golioth_fw_desired_parse(const uint8_t *payload, uint16_t payload_len,
 				   &manifest_sequence_number);
 
 	qerr = QCBORDecode_GetError(&decode_ctx);
-	if (qerr != QCBOR_SUCCESS) {
+	switch (qerr) {
+	case QCBOR_SUCCESS:
+		break;
+	case QCBOR_ERR_LABEL_NOT_FOUND:
+		LOG_DBG("No sequence-number found in manifest");
+		err = -ENOENT;
+		goto exit_root_map;
+	default:
 		LOG_ERR("Failed to get manifest bstr: %d (%s)", qerr, qcbor_err_to_str(qerr));
 		err = qcbor_error_to_posix(qerr);
 		goto exit_root_map;

--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -137,7 +137,13 @@ static int golioth_desired_update(const struct coap_packet *update,
 	err = golioth_fw_desired_parse(payload, payload_len,
 				       dfu->version, &version_len,
 				       uri, &uri_len);
-	if (err) {
+	switch (err) {
+	case 0:
+		break;
+	case -ENOENT:
+		LOG_INF("No release rolled out yet");
+		return 0;
+	default:
 		LOG_ERR("Failed to parse desired version: %d", err);
 		return err;
 	}


### PR DESCRIPTION
So far those log messages were printed when there were no dfu releases rolled out yet:
```
  <err> golioth: Failed to get manifest bstr: 34 (QCBOR_ERR_LABEL_NOT_FOUND)
  <err> golioth_dfu: Failed to parse desired version: -13
```
Handle the case when sequence-number is not found in CBOR map and return -ENOENT to signal no "desired version". Handle that in samples/dfu/ application, so that following log messages are printed instead:
```
  <inf> golioth_dfu: No release rolled out yet
```