### PR TITLE
samples: hello: add missing 'esp32' overlay

### DIFF
--- a/samples/hello/boards/esp32.overlay
+++ b/samples/hello/boards/esp32.overlay
@@ -1,0 +1,3 @@
+&wifi {
+	status = "okay";
+};


### PR DESCRIPTION
Add missing overlay file that enabled WiFi node.

Fixes: d9860924182b ("bump Zephyr to tip of main (post 3.2.0-rc2)")