### PR TITLE
samples: dfu: fix typo in qemu_x86 configuration

### DIFF
--- a/samples/dfu/boards/qemu_x86.conf
+++ b/samples/dfu/boards/qemu_x86.conf
@@ -13,6 +13,5 @@ CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"
 CONFIG_BOOTLOADER_MCUBOOT=n
 CONFIG_IMG_MANAGER=n
 
-# There is not persistent storage supported currently with default QEMU
-# configuration
+# There is no persistent storage supported currently with default QEMU configuration
 CONFIG_SETTINGS=n


### PR DESCRIPTION
s/There is not/There is no/ in comment about CONFIG_SETTINGS=n.