### PR TITLE
gitlab-ci: add 'twister-qemu-goliothd' job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,6 +116,67 @@ pre-commit:
     reports:
       junit: reports/twister.xml
 
+#
+# Job depends on following environment variables:
+# - GOLIOTH_PROJECT_ID: used by 'goliothctl' (in this job script)
+# - GOLIOTH_DEVICE_NAME: used by 'goliothctl' (in tests scripts)
+#
+# - GOLIOTH_SYSTEM_SERVER_HOST: used by 'goliothctl' (in this job script) and by device firmware
+# - GOLIOTH_SYSTEM_SERVER_API_PORT: used by 'goliothctl' (in this job script)
+#
+# - GOLIOTH_SYSTEM_CLIENT_PSK_ID: used by device firmware
+# - GOLIOTH_SYSTEM_CLIENT_PSK: used by device firmware
+#
+# It is also assumed that a self-hosted goliothd is used and there is no authentication required by
+# 'goliothctl' at api URL http://${GOLIOTH_SYSTEM_SERVER_HOST}:${GOLIOTH_SYSTEM_SERVER_API_PORT}.
+#
+# Project with id ${GOLIOTH_PROJECT_ID} needs to exist and device with ${GOLIOTH_DEVICE_NAME} name
+# needs to be provisioned with ${GOLIOTH_SYSTEM_CLIENT_PSK_ID} and ${GOLIOTH_SYSTEM_CLIENT_PSK} as
+# DTLS credentials.
+#
+twister-qemu-goliothd:
+  extends: .twister
+  tags: [dev-tun]
+  resource_group: goliothd
+  script:
+    # Download 'goliothctl' and expose to $PATH
+    - mkdir -p bin
+    - >
+      wget https://storage.googleapis.com/golioth-cli-releases/goliothctl/latest/goliothctl_latest_linux_64bit.tar.gz
+      -O goliothctl.tar.gz
+    - tar -xzf goliothctl.tar.gz -C bin goliothctl
+    - PATH=$PWD/bin:$PATH
+    # Login to goliothd
+    - >
+      goliothctl --apiUrl "http://${GOLIOTH_SYSTEM_SERVER_HOST}:${GOLIOTH_SYSTEM_SERVER_API_PORT}"
+      config set projectId ${GOLIOTH_PROJECT_ID}
+    - goliothctl project list
+    # Install samples/tests requirements
+    - pip3 install -r modules/lib/golioth/scripts/requirements-tests.txt
+    # Start QEMU networking utilities
+    - make -C tools/net-tools tunslip6
+    - tools/net-tools/loop-socat.sh &
+    - sleep 1
+    - sudo tools/net-tools/loop-slip-tap.sh &
+    - sleep 1
+    # Setup port forwarding for external network access and start network traffic recording
+    - apt-get update && apt-get install -y iptables tshark
+    - modules/lib/golioth/scripts/nat_config.py tap0
+    - mkdir -p reports
+    - tshark -f 'port 5684' -w reports/traffic.pcapng &
+    # Run tests
+    - >
+      zephyr/scripts/twister
+      -vvv
+      -t goliothd
+      -j 1
+      -p qemu_x86
+      -o reports
+      -T modules/lib/golioth
+  artifacts:
+    reports:
+      junit: reports/twister_report.xml
+
 twister:
   extends: .twister
   script:

--- a/scripts/nat_config.py
+++ b/scripts/nat_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+from argparse import ArgumentParser
+import re
+import subprocess
+
+def default_iface(ip="8.8.8.8"):
+    ip_r = subprocess.run(["ip", "route", "get", ip], capture_output=True, check=True)
+    match = re.search("dev (.+) src", ip_r.stdout.decode("utf-8"))
+    return match.group(1)
+
+def iptables_ipv4_forward():
+    subprocess.run(f"""
+    sysctl net.ipv4.ip_forward=1
+    """, shell=True)
+
+def iptables_nat_forward(iface_in, iface_out):
+    subprocess.run(f"""
+    iptables -t nat -C POSTROUTING -o {iface_out} -j MASQUERADE 2>/dev/null || \
+    iptables -t nat -A POSTROUTING -o {iface_out} -j MASQUERADE
+    """, check=True, shell=True)
+
+    subprocess.run(f"""
+    iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT \
+             2>/dev/null || \
+    iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+    """, check=True, shell=True)
+
+    subprocess.run(f"""
+    iptables -C FORWARD -i {iface_in} -o {iface_out} -j ACCEPT 2>/dev/null || \
+    iptables -A FORWARD -i {iface_in} -o {iface_out} -j ACCEPT
+    """, check=True, shell=True)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("int", help="Internal interface (usually TAP / PPP)")
+    parser.add_argument("-o", "--out",
+                        help="Interface with access to internet (usually ETH)")
+    args = parser.parse_args()
+
+    iface_out = args.out
+    if not iface_out:
+        iface_out = default_iface()
+        print(f"Using default interface: {iface_out}")
+
+    iptables_ipv4_forward()
+    iptables_nat_forward(args.int, iface_out)

--- a/scripts/requirements-tests.txt
+++ b/scripts/requirements-tests.txt
@@ -1,0 +1,1 @@
+pexpect


### PR DESCRIPTION
This job will run all QEMU tests and samples that require network access
and communication with 'goliothd'.

Add a script for configuring NAT with iptables, so that QEMU can access
external world.

Use `twister_report.xml` instead of `twister.xml`, as the former shows time
spent on each testcase separately and also trims down information about
target platform (which is obvious based on job name).