### PR TITLE
bump NCS to v2.1.0

### DIFF
--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -26,5 +26,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -26,5 +26,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
@@ -26,5 +26,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/samples/test/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/test/boards/nrf9160dk_nrf9160_ns.conf
@@ -21,5 +21,13 @@ CONFIG_NRF_MODEM_LIB=y
 # in poll() instead.
 CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
 
-# Conflicts with MBEDTLS_DTLS
-CONFIG_BUILD_WITH_TFM=n
+# Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
+# conflict with CONFIG_NRF_SECURITY
+CONFIG_MBEDTLS_TLS_LIBRARY=y
+CONFIG_MBEDTLS_SSL_PROTO_DTLS=y
+CONFIG_MBEDTLS_GCM_C=y
+# ... and disable options y-selected by NCS for no good reason
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED=n
+CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED=n
+# ... also increase heap size to "high enough to make it work"
+CONFIG_MBEDTLS_HEAP_SIZE=49152

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: a897e619b5ac15bb27f47affd4d42c6cf8e1f49f
+      revision: v2.1.0
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 


### PR DESCRIPTION
NRF_SECURITY module in NCS is enabled by default and we probably want to
keep it enabled, so that existing NCS users are not restricted by Golioth
SDK (e.g. by forcing NRF_SECURITY to be disabled). This module seems to
dropped old/legacy SPM module and now uses something new, which pulls in
NCS fork of mbedTLS as a dependency. This is expressed by 'select
DISABLE_MBEDTLS_BUILTIN if MBEDTLS' in both NRF_SECURITY and
NRF_SECURITY_BACKEND Kconfig options.

Using NCS fork of mbedTLS means selecting
CONFIG_MBEDTLS_TLS_LIBRARY (CONFIG_MBEDTLS_TLS_LIBRARY is NCS fork,
CONFIG_MBEDTLS_BUILTIN is Zephyr fork of mbedTLS).

NCS fork (as compared to Zephyr fork) of mbedTLS has set of Kconfig options
that are named differently (like CONFIG_MBEDTLS_SSL_PROTO_DTLS in NCS vs
CONFIG_MBEDTLS_DTLS in Zephyr), while other options are named the same. As
a result we are selecting CONFIG_MBEDTLS_SSL_PROTO_DTLS and
CONFIG_MBEDTLS_GCM_C to match what net/golioth/Kconfig file is selecting
automatically for the user.

Disable unused CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED and
CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED. Those are enabled by default
in NCS, by questionable 'default y if !NET_L2_OPENTHREAD'. Leaving them in
default state (y) breaks the build because of unmet dependencies (other
mbedTLS configuration options).

Increase mbedTLS heap size from 10kB (in prj.conf) to 48kB in order to make
it run. 32kB was still not enough in case of samples/hello/, so 48kB was
chosen to give enough room for future.

Tested with `lightdb`, `lightdb_stream`, `logging` and `dfu` samples.