### PR TITLE
sockets_offload_poll_wrapper: introduce new module and use it by nRF91

### DIFF
--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(golioth)
+add_subdirectory(sockets)

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -1,1 +1,2 @@
 rsource "golioth/Kconfig"
+rsource "sockets/Kconfig"

--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -230,24 +230,6 @@ config GOLIOTH_SYSTEM_CLIENT_RX_BUF_SIZE
 	  Size of receive buffer, which is used for reading data from network
 	  socket.
 
-choice GOLIOTH_SYSTEM_CLIENT_TIMEOUT
-	prompt "Communication timeout mechanism"
-	default GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_EVENTFD
-
-config GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_EVENTFD
-	bool "eventfd"
-	help
-	  Delayable work is used to detect communication timeouts and then
-	  eventfd mechanism is used to trigger mainloop.
-
-config GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL
-	bool "poll"
-	help
-	  Timeout parameter is passed to poll() system call, so that any receive
-	  communication timeouts are detected directly there.
-
-endchoice
-
 config GOLIOTH_SYSTEM_SETTINGS
 	bool "Load credentials from persistent settings"
 	depends on SETTINGS

--- a/net/sockets/CMakeLists.txt
+++ b/net/sockets/CMakeLists.txt
@@ -1,0 +1,1 @@
+zephyr_library_sources_ifdef(CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER sockets_offload_poll_wrapper.c)

--- a/net/sockets/Kconfig
+++ b/net/sockets/Kconfig
@@ -6,6 +6,7 @@
 
 config NET_SOCKETS_OFFLOAD_POLL_WRAPPER
 	bool "Socket offload poll() wrapper"
+	default y if NRF_MODEM_LIB
 	depends on NET_SOCKETS_OFFLOAD
 	help
 	  Enable library for communication with Golioth cloud.

--- a/net/sockets/Kconfig
+++ b/net/sockets/Kconfig
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2022 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+config NET_SOCKETS_OFFLOAD_POLL_WRAPPER
+	bool "Socket offload poll() wrapper"
+	depends on NET_SOCKETS_OFFLOAD
+	help
+	  Enable library for communication with Golioth cloud.
+
+if NET_SOCKETS_OFFLOAD_POLL_WRAPPER
+
+config NET_SOCKETS_OFFLOAD_POLL_WRAPPER_SOCKET_PRIORITY
+	int "Socket processing priority"
+	default 10
+	help
+	  Processing priority for sockets implementation. This value should be lower than offloaded
+	  sockets priority, which should be wrapped.
+
+	  See NET_SOCKETS_PRIORITY_DEFAULT help for details.
+
+config NET_SOCKETS_OFFLOAD_POLL_WRAPPER_THREAD_STACK_SIZE
+	int "Stack size of thread calling poll()"
+	default 1024
+	help
+	  Defines stack size of background thread calling poll() on offloaded
+	  socket.
+
+config NET_SOCKETS_OFFLOAD_POLL_WRAPPER_THREAD_PRIORITY
+	int "Priority of thread calling poll()"
+	default -2 if !PREEMPT_ENABLED
+	default 0
+	help
+	  Priority of helper thread calling poll().
+
+config NET_SOCKETS_OFFLOAD_POLL_WRAPPER_CONTEXT_MAX
+	int "Maximum number of dispatcher sockets created"
+	default POSIX_MAX_FDS
+	help
+	  Maximum number of dispatcher sockets created at a time. Note, that
+	  only sockets that has not been dispatched yet count into the limit.
+	  After a proper socket has been created for a given file descriptor,
+	  the dispatcher context is released and can be reused.
+
+endif # NET_SOCKETS_OFFLOAD_POLL_WRAPPER

--- a/net/sockets/sockets_offload_poll_wrapper.c
+++ b/net/sockets/sockets_offload_poll_wrapper.c
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2022 Golioth, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include <zephyr/net/socket.h>
+
+#include "sockets_internal.h"
+
+LOG_MODULE_REGISTER(net_sock_wrapper, CONFIG_NET_SOCKETS_LOG_LEVEL);
+
+__net_socket struct wrapper_context {
+	int fd;
+	int my_fd;
+	bool is_used;
+	struct k_poll_signal poll_signal;
+	struct k_work work;
+	struct k_work_q work_q;
+};
+
+static struct wrapper_context
+	wrapper_contexts[CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_CONTEXT_MAX];
+
+K_THREAD_STACK_ARRAY_DEFINE(sock_wrapper_poll_stack,
+			    CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_CONTEXT_MAX,
+			    CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_THREAD_STACK_SIZE);
+
+#define SOCK_WRAPPER_POLL_STACK_NAME(i, _) "threaded poll " #i
+
+static const char * const sock_wrapper_poll_stack_names[] = {
+	LISTIFY(CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_CONTEXT_MAX,
+		SOCK_WRAPPER_POLL_STACK_NAME, (,))
+};
+
+static K_MUTEX_DEFINE(wrapper_lock);
+
+static int sock_wrapper_create(int family, int type, int proto);
+
+static ssize_t sock_wrapper_recvfrom_vmeth(void *obj, void *buf,
+					   size_t max_len, int flags,
+					   struct sockaddr *addr,
+					   socklen_t *addrlen);
+
+static ssize_t sock_wrapper_sendto_vmeth(void *obj, const void *buf,
+					 size_t len, int flags,
+					 const struct sockaddr *addr,
+					 socklen_t addrlen);
+
+static void __wrapper_ctx_free(struct wrapper_context *wrapper)
+{
+	wrapper->fd = -1;
+	wrapper->my_fd = -1;
+	wrapper->is_used = false;
+}
+
+static int sock_wrapper_socket(int family, int type, int proto, bool *is_offloaded)
+{
+	STRUCT_SECTION_FOREACH(net_socket_register, sock_family) {
+		/* Ignore wrapper itself. */
+		if (sock_family->handler == sock_wrapper_create) {
+			continue;
+		}
+
+		if (sock_family->family != family &&
+		    sock_family->family != AF_UNSPEC) {
+			continue;
+		}
+
+		NET_ASSERT(sock_family->is_supported);
+
+		if (!sock_family->is_supported(family, type, proto)) {
+			continue;
+		}
+
+		*is_offloaded = sock_family->is_offloaded;
+
+		return sock_family->handler(family, type, proto);
+	}
+
+	errno = EAFNOSUPPORT;
+	return -1;
+}
+
+static ssize_t sock_wrapper_read_vmeth(void *obj, void *buffer, size_t count)
+{
+	return sock_wrapper_recvfrom_vmeth(obj, buffer, count, 0, NULL, 0);
+}
+
+static ssize_t sock_wrapper_write_vmeth(void *obj, const void *buffer, size_t count)
+{
+	return sock_wrapper_sendto_vmeth(obj, buffer, count, 0, NULL, 0);
+}
+
+static void sock_wrapper_poll_handler(struct k_work *work)
+{
+	struct wrapper_context *wrapper = CONTAINER_OF(work, struct wrapper_context, work);
+	struct zsock_pollfd pollfd = {
+		.fd = wrapper->fd,
+		.events = ZSOCK_POLLIN,
+		.revents = 0,
+	};
+	int retval;
+
+	retval = zsock_poll(&pollfd, 1, -1);
+
+	k_poll_signal_raise(&wrapper->poll_signal, retval);
+}
+
+static int sock_wrapper_poll_prepare_ctx(struct wrapper_context *wrapper,
+					 struct zsock_pollfd *pfd,
+					 struct k_poll_event **pev,
+					 struct k_poll_event *pev_end)
+{
+	if (pfd->events & ZSOCK_POLLIN) {
+		if (*pev == pev_end) {
+			return -ENOMEM;
+		}
+
+		(*pev)->obj = &wrapper->poll_signal;
+		(*pev)->type = K_POLL_TYPE_SIGNAL;
+		(*pev)->mode = K_POLL_MODE_NOTIFY_ONLY;
+		(*pev)->state = K_POLL_STATE_NOT_READY;
+		(*pev)++;
+	}
+
+	if (pfd->events & ZSOCK_POLLOUT) {
+		return -ENOTSUP;
+	}
+
+	k_work_submit_to_queue(&wrapper->work_q, &wrapper->work);
+
+	return 0;
+}
+
+static int sock_wrapper_poll_update_ctx(struct wrapper_context *wrapper,
+					struct zsock_pollfd *pfd,
+					struct k_poll_event **pev)
+{
+	if (pfd->events & ZSOCK_POLLIN) {
+		if ((*pev)->state != K_POLL_STATE_NOT_READY) {
+			pfd->revents |= ZSOCK_POLLIN;
+			k_poll_signal_reset(&wrapper->poll_signal);
+		}
+		(*pev)++;
+	}
+
+	return 0;
+}
+
+static int sock_wrapper_ioctl_vmeth(void *obj, unsigned int request, va_list args)
+{
+	struct wrapper_context *wrapper = obj;
+	const struct fd_op_vtable *vtable;
+	struct k_mutex *lock;
+	void *wrapped_obj;
+	int ret;
+
+	switch (request) {
+	case ZFD_IOCTL_POLL_PREPARE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
+		struct k_poll_event *pev_end;
+
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
+		pev_end = va_arg(args, struct k_poll_event *);
+
+		return sock_wrapper_poll_prepare_ctx(obj, pfd, pev, pev_end);
+	}
+
+	case ZFD_IOCTL_POLL_UPDATE: {
+		struct zsock_pollfd *pfd;
+		struct k_poll_event **pev;
+
+		pfd = va_arg(args, struct zsock_pollfd *);
+		pev = va_arg(args, struct k_poll_event **);
+
+		return sock_wrapper_poll_update_ctx(obj, pfd, pev);
+	}
+
+	default:
+		break;
+	}
+
+	wrapped_obj = z_get_fd_obj_and_vtable(wrapper->fd, &vtable, &lock);
+	if (!wrapped_obj) {
+		return -1;
+	}
+
+	if (lock) {
+		k_mutex_lock(lock, K_FOREVER);
+	}
+
+	ret = vtable->ioctl(wrapped_obj, request, args);
+
+	if (lock) {
+		k_mutex_unlock(lock);
+	}
+
+	return ret;
+}
+
+static int sock_wrapper_shutdown_vmeth(void *obj, int how)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_shutdown(wrapper->fd, how);
+}
+
+static int sock_wrapper_bind_vmeth(void *obj, const struct sockaddr *addr, socklen_t addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_bind(wrapper->fd, addr, addrlen);
+}
+
+static int sock_wrapper_connect_vmeth(void *obj, const struct sockaddr *addr,
+				      socklen_t addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_connect(wrapper->fd, addr, addrlen);
+}
+
+static int sock_wrapper_listen_vmeth(void *obj, int backlog)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_listen(wrapper->fd, backlog);
+}
+
+static int sock_wrapper_accept_vmeth(void *obj, struct sockaddr *addr, socklen_t *addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_accept(wrapper->fd, addr, addrlen);
+}
+
+static ssize_t sock_wrapper_sendto_vmeth(void *obj, const void *buf,
+					 size_t len, int flags,
+					 const struct sockaddr *addr,
+					 socklen_t addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_sendto(wrapper->fd, buf, len, flags, addr, addrlen);
+}
+
+static ssize_t sock_wrapper_sendmsg_vmeth(void *obj, const struct msghdr *msg,
+					  int flags)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_sendmsg(wrapper->fd, msg, flags);
+}
+
+static ssize_t sock_wrapper_recvfrom_vmeth(void *obj, void *buf,
+					   size_t max_len, int flags,
+					   struct sockaddr *addr,
+					   socklen_t *addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_recvfrom(wrapper->fd, buf, max_len, flags, addr, addrlen);
+}
+
+static int sock_wrapper_getsockopt_vmeth(void *obj, int level, int optname,
+					 void *optval, socklen_t *optlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_getsockopt(wrapper->fd, level, optname, optval, optlen);
+}
+
+static int sock_wrapper_setsockopt_vmeth(void *obj, int level, int optname,
+					 const void *optval, socklen_t optlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_setsockopt(wrapper->fd, level, optname, optval, optlen);
+}
+
+static int sock_wrapper_close_vmeth(void *obj)
+{
+	struct wrapper_context *wrapper = obj;
+	struct k_work_sync sync;
+	int retval = 0;
+
+	(void)k_mutex_lock(&wrapper_lock, K_FOREVER);
+
+	/* Close wrapped socket */
+	zsock_close(wrapper->fd);
+
+	/* Make sure that threaded poll() is no longer running */
+	k_work_cancel_sync(&wrapper->work, &sync);
+
+	__wrapper_ctx_free(wrapper);
+
+	k_mutex_unlock(&wrapper_lock);
+
+	return retval;
+}
+
+static int sock_wrapper_getpeername_vmeth(void *obj, struct sockaddr *addr,
+					  socklen_t *addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_getpeername(wrapper->fd, addr, addrlen);
+}
+
+static int sock_wrapper_getsockname_vmeth(void *obj, struct sockaddr *addr,
+					  socklen_t *addrlen)
+{
+	struct wrapper_context *wrapper = obj;
+
+	return zsock_getsockname(wrapper->fd, addr, addrlen);
+}
+
+static const struct socket_op_vtable sock_wrapper_fd_op_vtable = {
+	.fd_vtable = {
+		.read = sock_wrapper_read_vmeth,
+		.write = sock_wrapper_write_vmeth,
+		.close = sock_wrapper_close_vmeth,
+		.ioctl = sock_wrapper_ioctl_vmeth,
+	},
+	.shutdown = sock_wrapper_shutdown_vmeth,
+	.bind = sock_wrapper_bind_vmeth,
+	.connect = sock_wrapper_connect_vmeth,
+	.listen = sock_wrapper_listen_vmeth,
+	.accept = sock_wrapper_accept_vmeth,
+	.sendto = sock_wrapper_sendto_vmeth,
+	.sendmsg = sock_wrapper_sendmsg_vmeth,
+	.recvfrom = sock_wrapper_recvfrom_vmeth,
+	.getsockopt = sock_wrapper_getsockopt_vmeth,
+	.setsockopt = sock_wrapper_setsockopt_vmeth,
+	.getpeername = sock_wrapper_getpeername_vmeth,
+	.getsockname = sock_wrapper_getsockname_vmeth,
+};
+
+static int sock_wrapper_create(int family, int type, int proto)
+{
+	struct wrapper_context *wrapper = NULL;
+	bool is_offloaded;
+	int fd = -1;
+
+	fd = sock_wrapper_socket(family, type, proto, &is_offloaded);
+	if (fd < 0) {
+		return fd;
+	}
+
+	if (!is_offloaded) {
+		/*
+		 * Double check using ioctl(..., POLL_PREPARE, ...), as NCS does not register
+		 * nrf91_sockets as offloaded (but it should).
+		 */
+		const struct fd_op_vtable *vtable;
+		void *ctx;
+
+		ctx = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
+		if (ctx) {
+			struct zsock_pollfd pollfd = {
+				.fd = fd,
+			};
+			struct k_poll_event *pev;
+			int ret;
+
+			ret = z_fdtable_call_ioctl(vtable, ctx,
+						   ZFD_IOCTL_POLL_PREPARE,
+						   &pollfd,
+						   &pev, pev);
+			if (ret == -EXDEV) {
+				LOG_DBG("ioctl(%d, POLL_PREPARE) -> EXDEV", fd);
+				is_offloaded = true;
+			}
+		}
+
+	}
+
+	if (!is_offloaded) {
+		/* We are done, no need to wrap anything */
+		return fd;
+	}
+
+	LOG_DBG("wrapping fd %d", fd);
+
+	(void)k_mutex_lock(&wrapper_lock, K_FOREVER);
+
+	for (int i = 0; i < ARRAY_SIZE(wrapper_contexts); i++) {
+		if (wrapper_contexts[i].is_used) {
+			continue;
+		}
+
+		wrapper = &wrapper_contexts[i];
+		break;
+	}
+
+	if (!wrapper) {
+		errno = ENOMEM;
+		goto unlock_and_close;
+	}
+
+	wrapper->is_used = true;
+	wrapper->fd = fd;
+
+	fd = z_reserve_fd();
+	if (fd < 0) {
+		fd = wrapper->fd;
+		goto free_ctx;
+	}
+
+	wrapper->my_fd = fd;
+
+	z_finalize_fd(fd, wrapper,
+		      (const struct fd_op_vtable *)&sock_wrapper_fd_op_vtable);
+
+	k_mutex_unlock(&wrapper_lock);
+
+	return fd;
+
+free_ctx:
+	__wrapper_ctx_free(wrapper);
+
+unlock_and_close:
+	k_mutex_unlock(&wrapper_lock);
+
+	zsock_close(fd);
+
+	return -1;
+}
+
+static bool is_supported(int family, int type, int proto)
+{
+	return true;
+}
+
+NET_SOCKET_REGISTER(sock_wrapper,
+		    CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_SOCKET_PRIORITY,
+		    AF_UNSPEC, is_supported,
+		    sock_wrapper_create);
+
+static int sock_wrapper_init(const struct device *dev)
+{
+	struct k_work_queue_config cfg = {};
+	struct wrapper_context *wrapper;
+
+	ARG_UNUSED(dev);
+
+	for (wrapper = wrapper_contexts;
+	     wrapper < &wrapper_contexts[ARRAY_SIZE(wrapper_contexts)];
+	     wrapper++) {
+		int idx = wrapper - wrapper_contexts;
+
+		k_poll_signal_init(&wrapper->poll_signal);
+		k_work_init(&wrapper->work, sock_wrapper_poll_handler);
+		k_work_queue_init(&wrapper->work_q);
+
+		if (IS_ENABLED(CONFIG_THREAD_NAME)) {
+			cfg.name = sock_wrapper_poll_stack_names[idx];
+		}
+
+		k_work_queue_start(&wrapper->work_q,
+				   sock_wrapper_poll_stack[idx],
+				   K_THREAD_STACK_SIZEOF(sock_wrapper_poll_stack[idx]),
+				   CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER_THREAD_PRIORITY,
+				   &cfg);
+	}
+
+	return 0;
+}
+
+SYS_INIT(sock_wrapper_init, POST_KERNEL, 10);

--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/dfu/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,9 +22,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,10 +22,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,9 +22,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/hello_sporadic/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,10 +22,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/get/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/observe/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb/set/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_led/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/lightdb_stream/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/logging/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,9 +22,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/rpc/boards/nrf9160dk_nrf9160_ns.conf
@@ -22,10 +22,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/settings/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y

--- a/samples/test/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/test/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,9 +17,9 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Offloaded poll() does not support external events like eventfd, so use timeout
-# in poll() instead.
-CONFIG_GOLIOTH_SYSTEM_CLIENT_TIMEOUT_USING_POLL=y
+# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
+# (non-offloaded) Zephyr sockets.
+CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
 
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY

--- a/samples/test/boards/nrf9160dk_nrf9160_ns.conf
+++ b/samples/test/boards/nrf9160dk_nrf9160_ns.conf
@@ -17,10 +17,6 @@ CONFIG_LTE_AUTO_INIT_AND_CONNECT=y
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 
-# Enable offloaded sockets wrapper, which makes poll() behave similarly as with native
-# (non-offloaded) Zephyr sockets.
-CONFIG_NET_SOCKETS_OFFLOAD_POLL_WRAPPER=y
-
 # Use NCS fork of mbedTLS, as Zephyr built-in mbedTLS integration (CONFIG_MBEDTLS_BUILTIN) is in
 # conflict with CONFIG_NRF_SECURITY
 CONFIG_MBEDTLS_TLS_LIBRARY=y


### PR DESCRIPTION
There is a special ZFD_IOCTL_POLL_OFFLOAD ioctl() request used inside
poll() system call handling, which allows to offload whole poll() system
call to driver offloading sockets operations (like NCS' nRF91 sockets
driver). Offloading whole poll() execution doesn't allow to use Zephyr
native sockets (either from another network driver or just software
concepts like socketpair and eventfd). This is a huge restriction, because
it prevents "interrupting" poll() system call and blocks thread calling
poll() until new data arrives (at least when using POLLIN event).

Introduce offloaded sockets wrapper, which wraps all socket operations with
special behavior added specifically in poll() system call handling.
ZFD_IOCTL_POLL_PREPARE ioctl() request is handled (instead of returning
-EXDEV by offloaded sockets drivers) and execution of offloaded poll() is
actually scheduled in helper (one per socket) thread. Potentially
infinite (in case of no data arriving on socket) execution of poll() just
makes the helper thread to sleep, while the application thread is not
affected. Application thread is still notified about POLLIN event, by
raising k_poll_signal by helper thread. Such k_poll_signal event
notification is added next to other native Zephyr notification
mechanisms (like semaphore, fifo, msgq, pipe) to k_poll() doing the
heavylifting in poll() implementation. This means that such wrapped poll()
handling allows to combine it with other Zephyr sockets, eliminating major
restriction of "offloaded poll" mechanism.

Limitations of current implementation:
 * only POLLIN event is handled (no POLLOUT event handling),
 * POLLERR and POLLHUP are not propagated.

Use of this module allows to utilize eventfd mechanism, which is used by
all other platforms. For now this change should not result in functional
changes (this is just implementation mechanism change). However 'eventfd'
will be the requirement with the upcoming CoAP rework.