### PR TITLE
ci: add 'esp32' platform build tests with twister

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,10 +34,15 @@ jobs:
           west update -o=--depth=1 -n
           west patch --apply
 
+      - name: Download binary blobs
+        run: |
+          west blobs fetch hal_espressif
+
       - name: Run twister (non goliothd)
         run: >
           zephyr/scripts/twister
           -e goliothd
+          -p esp32
           -p nrf52840dk_nrf52840
           -p qemu_x86
           -o reports
@@ -47,6 +52,7 @@ jobs:
         run: >
           zephyr/scripts/twister
           -t goliothd -b
+          -p esp32
           -p nrf52840dk_nrf52840
           -p qemu_x86
           -o reports

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,10 +180,12 @@ twister-qemu-goliothd:
 twister:
   extends: .twister
   script:
+    - west blobs fetch hal_espressif
     # Build and run all non-goliothd samples/tests
     - >
       zephyr/scripts/twister
       -e goliothd
+      -p esp32
       -p nrf52840dk_nrf52840
       -p qemu_x86
       -o reports
@@ -192,18 +194,9 @@ twister:
     - >
       zephyr/scripts/twister
       -t goliothd -b
+      -p esp32
       -p nrf52840dk_nrf52840
       -p qemu_x86
-      -o reports
-      -T modules/lib/golioth
-
-twister-esp:
-  extends: .twister
-  script:
-    - west blobs fetch hal_espressif
-    - >
-      zephyr/scripts/twister
-      -p esp32
       -o reports
       -T modules/lib/golioth
 


### PR DESCRIPTION
Today ESP32 platform is supported by Zephyr SDK and the only distinct thing
about this platform is the need for downloading binary blobs. Those blobs
are downloaded now with Zephyr upstream feature called `west blobs`.

Just merge `twister-esp` GitLab CI job into `twister` for code deduplication.

For GitHub CI add `esp32` platform to twister invocation. This is making 
(non NCS) twister build-only tests in GitHub Actionn equivalent to GitLab CI.