### PR TITLE
coap_req: allow NULL callback

### DIFF
--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -354,6 +354,12 @@ void golioth_coap_req_process_rx(struct golioth_client *client, const struct coa
 	k_mutex_unlock(&client->coap_reqs_lock);
 }
 
+/* Default request callback, in case the caller does not specify one */
+static int default_req_cb(struct golioth_req_rsp *rsp)
+{
+	return 0;
+}
+
 static int golioth_coap_req_init(struct golioth_coap_req *req,
 				 struct golioth_client *client,
 				 enum coap_method method,
@@ -372,7 +378,7 @@ static int golioth_coap_req_init(struct golioth_coap_req *req,
 	}
 
 	req->client = client;
-	req->cb = cb;
+	req->cb = (cb ? cb : default_req_cb);
 	req->user_data = user_data;
 	req->request_wo_block2.offset = 0;
 	req->reply.age = 0;

--- a/net/golioth/coap_req.h
+++ b/net/golioth/coap_req.h
@@ -119,7 +119,7 @@ int golioth_coap_req_schedule(struct golioth_coap_req *req);
  * @param[in] format Content type
  * @param[in] data CoAP request payload (NULL if no payload should be appended)
  * @param[in] data_len Length of CoAP request payload
- * @param[in] cb Callback executed on response received, timeout or error
+ * @param[in] cb Callback executed on response received, timeout or error. Can be NULL.
  * @param[in] user_data User data passed to @p cb
  * @param[in] flags Flags (@sa golioth_coap_req_flags)
  *


### PR DESCRIPTION
Previously, the cb parameter of golioth_coap_req_cb was required. If it was set to NULL, the system would crash due to NULL dereference.

There have been a couple of instances of crashes which were due to this behavior. In one case, it was inadvertant (user meant to set a callback, but forgot). In the other case, it was intentional (rpc.c and settings.c both set the callback to NULL when sending the response, because they don't care about the response).

It seems like the most reasonable thing to do is to allow for a NULL callback, since there are legitimate requests that don't care to be called back ("fire and forget").

For cases where setting a NULL callback is unintentional, the user will be alerted soon enough when they realize that nothing is happening in response to their request (because they forget to set the callback). But at least there won't be a system crash (which can be hard to track down).

Signed-off-by: Nick Miller <nick@golioth.io>