### PR TITLE
golioth: add golioth_req_rsp_default_handler() default response handler

### DIFF
--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -354,12 +354,6 @@ void golioth_coap_req_process_rx(struct golioth_client *client, const struct coa
 	k_mutex_unlock(&client->coap_reqs_lock);
 }
 
-/* Default request callback, in case the caller does not specify one */
-static int default_req_cb(struct golioth_req_rsp *rsp)
-{
-	return 0;
-}
-
 static int golioth_coap_req_init(struct golioth_coap_req *req,
 				 struct golioth_client *client,
 				 enum coap_method method,
@@ -378,7 +372,7 @@ static int golioth_coap_req_init(struct golioth_coap_req *req,
 	}
 
 	req->client = client;
-	req->cb = (cb ? cb : default_req_cb);
+	req->cb = (cb ? cb : golioth_req_rsp_default_handler);
 	req->user_data = user_data;
 	req->request_wo_block2.offset = 0;
 	req->reply.age = 0;

--- a/net/golioth/golioth_utils.c
+++ b/net/golioth/golioth_utils.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(golioth);
+
 #include "golioth_utils.h"
 
 static enum coap_block_size max_block_size_from_payload_len(uint16_t payload_len)
@@ -23,4 +26,18 @@ static enum coap_block_size max_block_size_from_payload_len(uint16_t payload_len
 enum coap_block_size golioth_estimated_coap_block_size(struct golioth_client *client)
 {
 	return max_block_size_from_payload_len(client->rx_buffer_len);
+}
+
+int golioth_req_rsp_default_handler(struct golioth_req_rsp *rsp)
+{
+	const char *info = rsp->user_data;
+
+	if (rsp->err) {
+		LOG_ERR("Error response (%s): %d", info ? info : "app", rsp->err);
+		return 0;
+	}
+
+	LOG_HEXDUMP_DBG(rsp->data, rsp->len, info ? info : "RSP");
+
+	return 0;
 }

--- a/net/golioth/golioth_utils.h
+++ b/net/golioth/golioth_utils.h
@@ -11,4 +11,16 @@
 
 enum coap_block_size golioth_estimated_coap_block_size(struct golioth_client *client);
 
+/**
+ * @brief Default response handler
+ *
+ * Default response handler, which generates error logs in case of errors and debug logs in case of
+ * success.
+ *
+ * @param rsp Response information
+ *
+ * @retval 0 In every case
+ */
+int golioth_req_rsp_default_handler(struct golioth_req_rsp *rsp);
+
 #endif /* __NET_GOLIOTH_GOLIOTH_UTILS_H__ */

--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -34,6 +34,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth);
 
+#include "golioth_utils.h"
+
 #define GOLIOTH_RPC_PATH ".rpc"
 #define GOLIOTH_RPC_STATUS_PATH ".rpc/status"
 #define GOLIOTH_RPC_MAX_RESPONSE_LEN 256
@@ -44,7 +46,7 @@ static int send_response(struct golioth_client *client,
 	return golioth_coap_req_cb(client, COAP_METHOD_POST, PATHV(GOLIOTH_RPC_STATUS_PATH),
 				   COAP_CONTENT_FORMAT_APP_CBOR,
 				   coap_payload, coap_payload_len,
-				   NULL, NULL,
+				   golioth_req_rsp_default_handler, "RPC response ACK",
 				   GOLIOTH_COAP_REQ_NO_RESP_BODY);
 }
 

--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -42,6 +42,8 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(golioth);
 
+#include "golioth_utils.h"
+
 #define GOLIOTH_SETTINGS_PATH ".c"
 #define GOLIOTH_SETTINGS_STATUS_PATH ".c/status"
 #define GOLIOTH_SETTINGS_MAX_NAME_LEN 63 /* not including NULL */
@@ -61,7 +63,7 @@ static int send_coap_response(struct golioth_client *client,
 	return golioth_coap_req_cb(client, COAP_METHOD_POST, PATHV(GOLIOTH_SETTINGS_STATUS_PATH),
 				   COAP_CONTENT_FORMAT_APP_CBOR,
 				   coap_payload, coap_payload_len,
-				   NULL, NULL,
+				   golioth_req_rsp_default_handler, "Settings response ACK",
 				   GOLIOTH_COAP_REQ_NO_RESP_BODY);
 }
 


### PR DESCRIPTION
Replace static default_req_cb() with a golioth_req_rsp_default_handler() that produces error/debug messages on received response. Especially error messages are useful in case of CoAP ACK timeout or non-2 (non-success) CoAP response code class.

Add additional "hidden" (not documented to SDK consumers) functionality about logging additional module/component information string, so that it is easier to locate source component from specific log comes from. As an example for settings.c this is what will appear in Zephyr console:

```
  <dbg> golioth: Settings response ACK
                 73 65 74 74 69 6e 67 73  20 73 79 6e 63 65 64  |settings  synced
```

as a result of successful acknowledgment, when debug logs are enabled.

Make this function private to SDK internal implementation, so that above experimental "component infrmation" logging won't be used by SDK consumers.