### PR TITLE
samples: pytest: improvements and fixes

### DIFF
--- a/samples/lightdb/delete/pytest/test_sample.py
+++ b/samples/lightdb/delete/pytest/test_sample.py
@@ -17,7 +17,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def device_name():

--- a/samples/lightdb/get/pytest/test_sample.py
+++ b/samples/lightdb/get/pytest/test_sample.py
@@ -19,7 +19,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def device_name():

--- a/samples/lightdb/get/pytest/test_sample.py
+++ b/samples/lightdb/get/pytest/test_sample.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 from contextlib import suppress
 import json
 import logging
@@ -56,7 +57,6 @@ def goliothctl_readline(goliothctl, timeout):
 def test_lightdb_counter_get(initial_timeout):
     magic_value = 8664100
     expected_updates = 5
-    payload_pattern = re.compile(r"payload: (\d+)")
 
     try:
         counter_expected = magic_value
@@ -79,11 +79,11 @@ def test_lightdb_counter_get(initial_timeout):
 
             assert "message" in entry, f"No 'message' in {entry}"
 
-            payload = payload_pattern.match(entry["message"])
-            if not payload:
+            if "Counter" not in entry["message"]:
                 continue
 
-            counter_logged = int(payload[1])
+            binary_value = base64.decodebytes(entry["metadata"]["hexdump"].encode())
+            counter_logged = int(binary_value.decode())
 
             logging.info("Logged %s (expected %s)", counter_logged, counter_expected)
 

--- a/samples/lightdb/observe/pytest/test_sample.py
+++ b/samples/lightdb/observe/pytest/test_sample.py
@@ -20,7 +20,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def device_name():

--- a/samples/lightdb/observe/pytest/test_sample.py
+++ b/samples/lightdb/observe/pytest/test_sample.py
@@ -7,7 +7,6 @@ from contextlib import suppress
 import json
 import logging
 import os
-import re
 import subprocess
 import time
 
@@ -57,7 +56,6 @@ def goliothctl_readline(goliothctl, timeout):
 def test_lightdb_counter_observe(initial_timeout):
     magic_value = 8664100
     expected_updates = 5
-    payload_pattern = re.compile(r"Counter.*|(\d+)")
 
     try:
         args = goliothctl_args() + ["logs", "listen", "--json", device_name()]
@@ -86,7 +84,6 @@ def test_lightdb_counter_observe(initial_timeout):
 
             assert "message" in entry, f"No 'message' in {entry}"
 
-            payload = payload_pattern.match(entry["message"])
             if "Counter" not in entry["message"]:
                 continue
 

--- a/samples/lightdb/set/pytest/test_sample.py
+++ b/samples/lightdb/set/pytest/test_sample.py
@@ -16,7 +16,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def goliothctl_readline(goliothctl, timeout):

--- a/samples/lightdb_led/pytest/test_sample.py
+++ b/samples/lightdb_led/pytest/test_sample.py
@@ -19,7 +19,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def device_name():

--- a/samples/lightdb_stream/pytest/test_sample.py
+++ b/samples/lightdb_stream/pytest/test_sample.py
@@ -16,7 +16,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def goliothctl_readline(goliothctl, timeout):

--- a/samples/logging/pytest/test_sample.py
+++ b/samples/logging/pytest/test_sample.py
@@ -19,7 +19,10 @@ DEFAULT_TIMEOUT = 30
 
 @pytest.fixture()
 def initial_timeout(request):
-    return request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
+    timeout = request.config.getoption('--initial-timeout')
+    if timeout is None:
+        timeout = DEFAULT_TIMEOUT
+    return timeout
 
 
 def device_name():


### PR DESCRIPTION
All samples but DFU are not handlng properly the case when
--initial-timeout is not provided (which is true for all platforms other
than nRF91). request.config.getoption('--initial-timeout', DEFAULT_TIMEOUT)
retured None, which means that None was passed to pexpect.expect() or
pexpect.readline() methods. This was resulting in infinite timeouts,
instead of default 30s timeouts.

Copy initial_timeout fixture from DFU's pytest script to all other samples'
scripts.

Remove dead code in lightdb/observe pytest script.

Fix lightdb/get pytest script to handle counter values logged as hexdump. 
See commit message for details why this was not detected in CI (and why
other bugs might be missed as well).
