### PR TITLE
samples: dfu: report FW state and reboot from main thread

### DIFF
--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -179,17 +179,6 @@ free_req:
 	return err;
 }
 
-static int golioth_fw_report_state_cb(struct golioth_req_rsp *rsp)
-{
-	if (rsp->err) {
-		LOG_ERR("Failed to report FW state: %d", rsp->err);
-	} else {
-		LOG_INF("Successfully reported FW state");
-	}
-
-	return 0;
-}
-
 int golioth_fw_report_state(struct golioth_client *client,
 			    const char *package_name,
 			    const char *current_version,
@@ -224,10 +213,10 @@ int golioth_fw_report_state(struct golioth_client *client,
 		return qcbor_error_to_posix(qerr);
 	}
 
-	return golioth_coap_req_cb(client, COAP_METHOD_POST,
-				   PATHV(GOLIOTH_FW_REPORT_STATE, package_name),
-				   GOLIOTH_CONTENT_FORMAT_APP_CBOR,
-				   encode_bufc.ptr, encoded_len,
-				   golioth_fw_report_state_cb, NULL,
-				   0);
+	return golioth_coap_req_sync(client, COAP_METHOD_POST,
+				     PATHV(GOLIOTH_FW_REPORT_STATE, package_name),
+				     GOLIOTH_CONTENT_FORMAT_APP_CBOR,
+				     encode_bufc.ptr, encoded_len,
+				     NULL, NULL,
+				     0);
 }


### PR DESCRIPTION
So far there were 3 threads involved:
 * Zephyr main
   * initialize network
   * start Golioth system client
 * Golioth system_client
   * handle incoming Golioth communication
   * report FW states
 * Zephyr sysworkq
   * trigger reboot

This is overly complicated and makes callbacks implementation hard to read
due to FW state reporting logic taking most of callback body.

Change implementation to utilize only 2 threads instead, with following
changes:
 * Zephyr main
   * initialize network (as before)
   * start Golioth system client (as before)
   * report FW reporting (new)
   * trigger reboot (new)
 * Golioth system_client
   * handle incoming Golioth communication

There is little data shared among those threads and most important thing
is to notify about state of FW download. For that reason use
semaphores, which make main() execution continue step by step, making
overall logic easy to follow.

This change solves one of the issues with pytest scripts expecting a
specific sequence of FW states. So far this sequence was not followed from
time to time, due to UDP packets reordering. This issue is now partly
solved by reporting FW states from Zephyr main thread and remaining fix
will be a conversion from asynchronous to synchronous
golioth_fw_report_state() API.

As a consequence of above, change `golioth_fw_report_state()` API to be synchronous.
This API does not take any callback, which means that it is not possible to
handle any communication errors or error responses from server. The main
reason why its implementation used golioth_coap_req_cb() (in [1]) was to
reduce breaking changes by allowing users to call this API from
system_client thread (which is not possible for synchronous APIs).

As right now samples/dfu/ has been updated to report FW state (i.e. call
golioth_fw_report_state() API) from main application thread, there is
little reason to keep golioth_fw_report_state() asynchronous.

If asynchronous API will be required in future, then such API would need to
take callback argument similar to other services (like LightDB and LightDB
Stream). Such API is not introduced now, as that would either require
second DFU sample with a slightly different flow or alternatively unit
tests for this new callback-based API.