### PR TITLE
samples: lightdb: delete: add missing esp32.overlay

### DIFF
--- a/samples/lightdb/delete/boards/esp32.overlay
+++ b/samples/lightdb/delete/boards/esp32.overlay
@@ -1,0 +1,3 @@
+&wifi {
+	status = "okay";
+};


### PR DESCRIPTION
This is needed to get WiFi working with ESP32 board.