### PR TITLE
github-ci: update to actions/checkout@v3

### DIFF
--- a/.github/disabled_workflows/test_mimxrt1060.yml
+++ b/.github/disabled_workflows/test_mimxrt1060.yml
@@ -21,7 +21,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/lib/golioth
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download build tarball
         uses: actions/download-artifact@v3

--- a/.github/disabled_workflows/test_nrf9160dk.yml
+++ b/.github/disabled_workflows/test_nrf9160dk.yml
@@ -26,7 +26,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/lib/golioth
 
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download build tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,7 +18,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/lib/golioth
 

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,7 +13,7 @@ jobs:
       image: zephyrprojectrtos/ci:v0.24.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/lib/golioth
           fetch-depth: 0

--- a/.github/workflows/firebase-doxygen-main.yml
+++ b/.github/workflows/firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -13,7 +13,7 @@ jobs:
       image: jorisroovers/gitlint:0.15.1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       image: kiwicom/pre-commit:2.9.3
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -21,7 +21,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: modules/lib/golioth
 
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download build tarball
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This suppresses following warning:

> Node.js 12 actions are deprecated.