### PR TITLE
coap_req: add timestamp comparison to OBSERVE notifications

### DIFF
--- a/net/golioth/coap_req.h
+++ b/net/golioth/coap_req.h
@@ -39,7 +39,8 @@ struct golioth_coap_pending {
  * @note Modeled after #coap_reply
  */
 struct golioth_coap_reply {
-	int age;		/* needed for observations only */
+	int seq;		/* needed for observations only */
+	int64_t ts;		/* needed for observations only */
 };
 
 /**


### PR DESCRIPTION
As per CoAP OBSERVE RFC7641 section "4.4. Reordering", server can choose
any arbitrary number as initial sequence number as OBSERVE CoAP option
value. In paticular, local clock can be used to generate sequence numbers,
so that specific sequence number values do not need to be remembered on
server side.

In order to handle that successfully, client needs to implement timestamp
comparison as per RFC7641 section "3.4. Reordering". So far only sequence
number comparison was used, so add missing timestamp comparison to be
compliant with CoAP OBSERVE spec and handle newest Golioth backend
behavior.

While at it, change wording of 'age' to 'seq' and/or 'sequence number', so
it will match what is used in RFC7641 specification.