### PR TITLE
coap_req: fix golioth_coap_reqs_poll_prepare() docs

### DIFF
--- a/net/golioth/coap_req.h
+++ b/net/golioth/coap_req.h
@@ -169,7 +169,7 @@ int golioth_coap_req_sync(struct golioth_client *client,
  * #golioth_coap_req_cb_t callback. Since all created requests are scheduled with timeout of 0, it
  * means that this function also handles sending of the request for the first time.
  *
- * @param[in] req CoAP request
+ * @param[in] client Client instance
  * @param[in] now Timestamp in msec of current event loop (usually output of k_uptime_get())
  *
  * @retval INT64_MAX Infinite timeout (in case request reached maximum retranmissions and was


### PR DESCRIPTION
`golioth_coap_reqs_poll_prepare()` does not get `req` as parameter, but
`client` instead. Fix doxygen docs that say otherwise.