### PR TITLE
sockets_offload_poll_wrapper: cancel work before socket close

### DIFF
--- a/net/sockets/sockets_offload_poll_wrapper.c
+++ b/net/sockets/sockets_offload_poll_wrapper.c
@@ -290,6 +290,12 @@ static int sock_wrapper_close_vmeth(void *obj)
 
 	(void)k_mutex_lock(&wrapper_lock, K_FOREVER);
 
+	/*
+	 * Start work cancellation, to make sure work won't be rerun in case
+	 * work is both in the running and queued state.
+	 */
+	k_work_cancel(&wrapper->work);
+
 	/* Close wrapped socket */
 	zsock_close(wrapper->fd);
 


### PR DESCRIPTION
So far there was a possibility that work item was in both RUNNING and
QUEUED states. As a result of `zsock_close()` call, threaded (executed from
workqueue) `zsock_poll()` returned. However just because work was QUEUED,
`sock_wrapper_poll_handler()` was entered once again by workqueue thread.
Subsequent work cancellation with `k_work_cancel_sync()` could no longer be
finished, as work was waiting once again on `zsock_close()`.

Start work cancellation using `k_work_cancel()` just before `zsock_close()`
is invoked. This clears QUEUED state from work item, so
`sock_wrapper_poll_handler()` is not reentered. After `zsock_close()` has
returned, it is safe to call `k_work_cancel_sync()` to finish work
cancellation and make sure that `sock_wrapper_poll_handler()` (hence
`zsock_poll()`) is no longer running.