### PR TITLE
tests: lightdb: fix error handling and fix copy-paste error in log

### DIFF
--- a/tests/lightdb/src/main.c
+++ b/tests/lightdb/src/main.c
@@ -112,6 +112,7 @@ static int lightdb_get_handler(struct golioth_req_rsp *rsp)
 
 	if (rsp->err) {
 		LOG_ERR("Failed to receive value: %d", rsp->err);
+		async->err = rsp->err;
 		k_sem_give(&async->sem);
 		return rsp->err;
 	}

--- a/tests/lightdb/src/main.c
+++ b/tests/lightdb/src/main.c
@@ -111,7 +111,7 @@ static int lightdb_get_handler(struct golioth_req_rsp *rsp)
 	struct async_data *async = rsp->user_data;
 
 	if (rsp->err) {
-		LOG_ERR("Failed to receive counter value: %d", rsp->err);
+		LOG_ERR("Failed to receive value: %d", rsp->err);
 		k_sem_give(&async->sem);
 		return rsp->err;
 	}


### PR DESCRIPTION
This test does not expect any counter, so remove this word from log
message.

If there was an error during asynchronous (callback-based) request, then
such error was not propagated to `struct async_data` structure, but instead
it was still set to `0`, just like the API would be successful. Later, test
would discover a problem anyway, as received data would not match with
expected one. However, it is better to propagate error and not rely on data
comparison.