### PR TITLE
Kconfig: add GOLIOTH_SETTINGS_MAX_RESPONSE_LEN

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -144,6 +144,24 @@ config GOLIOTH_SETTINGS
 	  Enable Golioth Settings feature. Not to be confused
 	  with Zephyr's own Settings subsystem.
 
+config GOLIOTH_SETTINGS_MAX_RESPONSE_LEN
+	int "Max length of settings response sent to Golioth"
+	depends on GOLIOTH_SETTINGS
+	default 256
+	help
+	  Defines the maximum length, in bytes, of the client response sent to the Golioth
+	  server on CoAP endpoint "/.c/status".
+
+	  Internally, a buffer of this size will be created, which will store a
+	  CBOR-encoded response message.
+
+	  It's generally recommended to set this to a value of 50 * N, where N is the
+	  number of Golioth settings.
+
+	  The response length grows as a function of the number of errors encountered while
+	  processing Golioth settings. Each setting can have an error, so in the worst case
+	  you'd have an error for every setting you've defined in your Golioth project.
+
 config GOLIOTH_FW_PACKAGE_NAME_MAX_LEN
 	int "Maximum length of package name"
 	default 32


### PR DESCRIPTION
Before this change, the max length of the settings response was fixed at 256 (#define'd in the source code of settings.c). This was problematic for devices with many settings, because if there are multiple errors encountered while handling the settings, the response length becomes too large to fit in the response buffer, resulting in a QCBOR error:

QCBOREncode_FinishGetSize error: 1 (QCBOR_ERR_BUFFER_TOO_SMALL)

To accomodate users with lots of settings, make the response length configurable via Kconfig.

The recommendation of 50 * N for the max length is given because each error encountered results in a CBOR entry like:

{ "setting_key": string, "error_code": int }

The "setting_key" and "error_code" strings alone account for 21 bytes, then if you add in the name of the setting (string) and 1-byte error code, it can easily be 40-50 bytes for each error.

Signed-off-by: Nick Miller <nick@golioth.io>