### PR TITLE
net: add log message for invalid format

### DIFF
--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -204,6 +204,10 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
 	LOG_DBG("CoAP response code: 0x%x (class %u detail %u)",
 		(unsigned int)code, (unsigned int)(code >> 5), (unsigned int)(code & 0x1f));
 
+	if (code == COAP_RESPONSE_CODE_BAD_REQUEST) {
+		LOG_WRN("Server reports CoAP Bad Request. (Check payload formatting)");
+	}
+
 	err = golioth_coap_code_to_posix(code);
 	if (err) {
 		struct golioth_req_rsp rsp = {


### PR DESCRIPTION
Poorly formatted JSON is a common cause for errors when using LightDB State/Stream. This commit watches for the -EFAULT error code and publishes a warning to check the formatting.