### PR TITLE
samples/dfu: clear dfu update_ctx before observing

### DIFF
--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -152,6 +152,7 @@ static void golioth_on_connect(struct golioth_client *client)
 
 	k_sem_give(&sem_connected);
 
+	memset(&update_ctx, 0, sizeof(update_ctx));
 	err = golioth_fw_observe_desired(client, golioth_desired_update, &update_ctx);
 	if (err) {
 		LOG_ERR("Failed to start observation of desired FW: %d", err);


### PR DESCRIPTION
This fixes an issue where DFU cannot proceed due to:

golioth_dfu: Ignoring new desired firmware, as downloading already started

This issue can occur if DFU gets interrupted by a disconnect. When DFU starts, the downloading_started field of struct dfu_ctx is set to true, but it is never cleared after that point. Upon reconnection, golioth_fw_observe_desired() will be called again, but since the downloading_started flag has already been set, DFU cannot proceed.

Clearing the update_ctx before calling golioth_fw_observe_desired() will ensure the flag is cleared, and will result in the DFU process starting from the beginning if a client disconnects and reconnects.

Signed-off-by: Nick Miller <nick@golioth.io>