### PR TITLE
rpc, settings: remove automatic observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - TBD
+### Breaking Changes
+- calling `golioth_rpc_register()` no longer automatically observes. The RPC observation is now
+  established only if the user calls `golioth_rpc_observe()`. Existing applications that use
+  RPCs will need to call `golioth_rpc_observe()` in the `on_connect` callback. Additionally, it's
+  recommended to move any calls to `golioth_rpc_register()` outside of the `on_connect` callback,
+  to avoid registering the same RPC method multiple times. See the `rpc` sample for reference.
+- calling `golioth_settings_register_callback()` no longer automatically observes. The settings
+  observation is now established only if the user calls `golioth_settings_observe()`.
+  Existing applications that use settings will need to call `golioth_settings_observe()` in the
+  `on_connect` callback. See the `settings` sample for reference.
+
 ## [0.5.0] - 2022-12-13
 ### Added
 - Python library and CLI tools for accessing Golioth REST API (`scripts/python/golioth/`)

--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -71,8 +71,6 @@ struct golioth_client {
 	void (*wakeup)(struct golioth_client *client);
 
 	struct golioth_rpc rpc;
-	struct k_mutex rpc_mutex;
-
 	struct golioth_settings settings;
 };
 

--- a/include/net/golioth/rpc.h
+++ b/include/net/golioth/rpc.h
@@ -140,6 +140,24 @@ int golioth_rpc_register(struct golioth_client *client,
 			 golioth_rpc_cb_fn callback,
 			 void *callback_arg);
 
+/**
+ * @brief Observe for RPC method invocations
+ *
+ * User applications should call this function in the `on_connect` callback,
+ * if they wish to observe RPCs.
+ *
+ * Establishes a single observation for endpoint ".rpc".
+ * The handler for this endpoint will look up the method in a table of
+ * registered RPCs (from @ref golioth_rpc_register) and invoke the callback
+ * if the method is found.
+ *
+ * @param client Client instance
+ *
+ * @return 0 - RPC observation established
+ * @return <0 - Error observing RPC
+ */
+int golioth_rpc_observe(struct golioth_client *client);
+
 /** @} */
 
 #endif /* GOLIOTH_INCLUDE_NET_GOLIOTH_RPC_H_ */

--- a/include/net/golioth/rpc.h
+++ b/include/net/golioth/rpc.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <zephyr/net/coap.h>
+#include <zephyr/kernel.h>
 
 struct _QCBOREncodeContext;
 struct _QCBOREncodeContext;
@@ -106,11 +107,21 @@ struct golioth_rpc_method {
  */
 struct golioth_rpc {
 #if defined(CONFIG_GOLIOTH_RPC)
-	bool initialized;
 	struct golioth_rpc_method methods[CONFIG_GOLIOTH_RPC_MAX_NUM_METHODS];
 	int num_methods;
+	struct k_mutex mutex;
 #endif
 };
+
+/**
+ * @brief Initialize RPC
+ *
+ * @param client Client instance
+ *
+ * @return 0 - RPC initialized successfully
+ * @return Otherwise - RPC error initializing
+ */
+int golioth_rpc_init(struct golioth_client *client);
 
 /**
  * @brief Register an RPC method

--- a/include/net/golioth/settings.h
+++ b/include/net/golioth/settings.h
@@ -128,6 +128,23 @@ struct golioth_settings {
 int golioth_settings_register_callback(struct golioth_client *client,
 				       golioth_settings_cb callback);
 
+/**
+ * @brief Observe for Settings
+ *
+ * User applications should call this function in the `on_connect` callback,
+ * if they wish to observe Settings.
+ *
+ * Establishes a single observation for the settings endpoint ".c".
+ * The handler for this observation will call the callback registered with
+ * @ref golioth_settings_register_callback.
+ *
+ * @param client Client instance
+ *
+ * @return 0 - Settings observation established
+ * @return <0 - Error observing Settings
+ */
+int golioth_settings_observe(struct golioth_client *client);
+
 /** @} */
 
 #endif /* GOLIOTH_INCLUDE_NET_GOLIOTH_SETTINGS_H_ */

--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -152,7 +152,7 @@ static int on_rpc(struct golioth_req_rsp *rsp)
 	return send_response(client, response_buf, response_len);
 }
 
-static int golioth_rpc_observe(struct golioth_client *client)
+int golioth_rpc_observe(struct golioth_client *client)
 {
 	return golioth_coap_req_cb(client, COAP_METHOD_GET, PATHV(GOLIOTH_RPC_PATH),
 				   GOLIOTH_CONTENT_FORMAT_APP_CBOR,
@@ -189,9 +189,6 @@ int golioth_rpc_register(struct golioth_client *client,
 	method->callback_arg = callback_arg;
 
 	client->rpc.num_methods++;
-	if (client->rpc.num_methods == 1) {
-		status = golioth_rpc_observe(client);
-	}
 
 cleanup:
 	k_mutex_unlock(&client->rpc.mutex);

--- a/net/golioth/settings.c
+++ b/net/golioth/settings.c
@@ -237,7 +237,7 @@ static int on_setting(struct golioth_req_rsp *rsp)
 	return finalize_and_send_response(client, &settings_response);
 }
 
-static int golioth_settings_observe(struct golioth_client *client)
+int golioth_settings_observe(struct golioth_client *client)
 {
 	return golioth_coap_req_cb(client, COAP_METHOD_GET, PATHV(GOLIOTH_SETTINGS_PATH),
 				   GOLIOTH_CONTENT_FORMAT_APP_CBOR,
@@ -265,5 +265,5 @@ int golioth_settings_register_callback(struct golioth_client *client,
 		client->settings.initialized = true;
 	}
 
-	return golioth_settings_observe(client);
+	return 0;
 }

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -10,6 +10,7 @@ LOG_MODULE_REGISTER(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_LOG_LEVEL);
 #include <errno.h>
 #include <logging/golioth.h>
 #include <net/golioth/system_client.h>
+#include <net/golioth/rpc.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/posix/sys/eventfd.h>
@@ -252,6 +253,14 @@ static int client_initialize(struct golioth_client *client)
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_GOLIOTH)) {
 		log_backend_golioth_init(client);
+	}
+
+	if (IS_ENABLED(CONFIG_GOLIOTH_RPC)) {
+		err = golioth_rpc_init(client);
+		if (err) {
+			LOG_ERR("Failed to initialize RPC: %d", err);
+			return err;
+		}
 	}
 
 	return 0;

--- a/samples/rpc/src/main.c
+++ b/samples/rpc/src/main.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(golioth_rpc, LOG_LEVEL_DBG);
 #include <samples/common/net_connect.h>
 #include <qcbor/qcbor.h>
 #include <qcbor/qcbor_spiffy_decode.h>
-#include <assert.h>
 
 static struct golioth_client *client = GOLIOTH_SYSTEM_CLIENT_GET();
 
@@ -40,12 +39,9 @@ static enum golioth_rpc_status on_multiply(QCBORDecodeContext *request_params_ar
 
 static void golioth_on_connect(struct golioth_client *client)
 {
-	assert(IS_ENABLED(CONFIG_GOLIOTH_RPC));
-
-	int err = golioth_rpc_register(client, "multiply", on_multiply, NULL);
-
+	int err = golioth_rpc_observe(client);
 	if (err) {
-		LOG_ERR("Failed to register RPC: %d", err);
+		LOG_ERR("Failed to observe RPC: %d", err);
 	}
 }
 
@@ -59,6 +55,12 @@ void main(void)
 
 	client->on_connect = golioth_on_connect;
 	golioth_system_client_start();
+
+	int err = golioth_rpc_register(client, "multiply", on_multiply, NULL);
+
+	if (err) {
+		LOG_ERR("Failed to register RPC: %d", err);
+	}
 
 	while (true) {
 		k_sleep(K_SECONDS(5));

--- a/samples/settings/src/main.c
+++ b/samples/settings/src/main.c
@@ -46,11 +46,7 @@ enum golioth_settings_status on_setting(
 static void golioth_on_connect(struct golioth_client *client)
 {
 	if (IS_ENABLED(CONFIG_GOLIOTH_SETTINGS)) {
-		int err = golioth_settings_register_callback(client, on_setting);
-
-		if (err) {
-			LOG_ERR("Failed to register settings callback: %d", err);
-		}
+		golioth_settings_observe(client);
 	}
 }
 
@@ -63,6 +59,13 @@ void main(void)
 
 	if (IS_ENABLED(CONFIG_GOLIOTH_SAMPLES_COMMON)) {
 		net_connect();
+	}
+
+	if (IS_ENABLED(CONFIG_GOLIOTH_SETTINGS)) {
+		err = golioth_settings_register_callback(client, on_setting);
+		if (err) {
+			LOG_ERR("Failed to register settings callback: %d", err);
+		}
 	}
 
 	client->on_connect = golioth_on_connect;


### PR DESCRIPTION
Currently, when golioth_rpc_register() is called, an observation is automatically established (if it’s the first RPC method being registered).

Similarly, when golioth_settings_register_callback() is called, an observation is automatically established.

However, this “automatic observe” behavior has three main issues:

1. It might be unwanted in some user applications (e.g. low-power/low-data) that don’t want the overhead of observations

2. It’s inconsistent with the way observations work for DFU. For DFU, it’s expected that the user calls golioth_fw_observe_desired() in the on_connect callback (i.e. observations are not automatically established).

3. It can be unexpected/surprising that an API named “register callback” would also create an observation.

We should separate RPC and Settings registration from observation, and make the observation an explicit API call.

This is a breaking change, since user applications will need to be modified to call the new functions in the on_connect callback.