### PR TITLE
.github: fix documentation errors

### DIFF
--- a/.github/disabled_workflows/test_mimxrt1060.yml
+++ b/.github/disabled_workflows/test_mimxrt1060.yml
@@ -75,10 +75,9 @@ jobs:
   #
   # For item 4, the file needs to have contents like:
   #
-  # {
-  #   "golioth/psk-id": "device@project",
-  #   "golioth/psk": "supersecret"
-  # }
+  # settings:
+  #   golioth/psk-id: device@project
+  #   golioth/psk: supersecret
   #
   # The golioth credentials need to match a device on coap.golioth.dev
   hw_flash_and_test:

--- a/.github/disabled_workflows/test_nrf9160dk.yml
+++ b/.github/disabled_workflows/test_nrf9160dk.yml
@@ -63,7 +63,7 @@ jobs:
   #  1. Has installed the GitHub Actions self-hosted runner service
   #  2. Has nrfjprog already installed
   #  3. Has an environment variable defined for the serial port: CI_NRF9160DK_PORT
-  #  4. Has credentials defined in the file $HOME/credentials_nrf9160.yml
+  #  4. Has credentials defined in the file $HOME/credentials_nrf9160dk.yml
   #  5. Has an environment variabled defined for the JTAG serial number of the nRF91.
   #
   # It is the responsibility of the self-hosted runner admin to ensure
@@ -81,10 +81,9 @@ jobs:
   #
   # For item 4, the file needs to have contents like:
   #
-  # {
-  #   "golioth/psk-id": "device@project",
-  #   "golioth/psk": "supersecret"
-  # }
+  # settings:
+  #   golioth/psk-id: device@project
+  #   golioth/psk: supersecret
   #
   # The golioth credentials need to match a device on coap.golioth.dev
   #

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -58,7 +58,7 @@ jobs:
   #  1. Has installed the GitHub Actions self-hosted runner service
   #  2. Has nrfjprog already installed
   #  3. Has an environment variable defined for the serial port: CI_NRF52840DK_PORT
-  #  4. Has credentials defined in the file $HOME/credentials_nrf52840.yml
+  #  4. Has credentials defined in the file $HOME/credentials_nrf52840dk.yml
   #  5. Has an environment variabled defined for the JTAG serial number of the nRF52.
   #
   # It is the responsibility of the self-hosted runner admin to ensure
@@ -76,12 +76,11 @@ jobs:
   #
   # For item 4, the file needs to have contents like:
   #
-  # {
-  #   "wifi/ssid": "mywifissid",
-  #   "wifi/psk": "mywifipassword",
-  #   "golioth/psk-id": "device@project",
-  #   "golioth/psk": "supersecret"
-  # }
+  # settings:
+  #   wifi/ssid: mywifissid
+  #   wifi/psk: mywifipassword
+  #   golioth/psk-id: device@project
+  #   golioth/psk: supersecret
   #
   # The golioth credentials need to match a device on coap.golioth.dev
   #


### PR DESCRIPTION
* The .yml file should have been named `credentials_nrf{52840,9160}dk.yml`
* The format of the settings is YAML, not JSON