### PR TITLE
golioth: fix zsock_setsockopt(..., TLS_HOSTNAME, ...) API use

### DIFF
--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -71,13 +71,8 @@ static int golioth_setsockopt_dtls(struct golioth_client *client, int sock,
 		 * Subject Alternative Name, so providing string representation of IP address will
 		 * fail (during handshake). If this is the case, you can can still connect if you
 		 * modify the code below to set host to NULL, which disables hostname verification.
-		 *
-		 * NOTE: Zephyr TLS layer / mbedTLS API expect NULL terminated string. Length
-		 * (calculated with 'strlen') is ignored at Zephyr TLS layer. Though, we provide
-		 * length without NULL termination, just in case Zephyr/mbedTLS implementation would
-		 * change.
 		 */
-		ret = zsock_setsockopt(sock, SOL_TLS, TLS_HOSTNAME, host, strlen(host));
+		ret = zsock_setsockopt(sock, SOL_TLS, TLS_HOSTNAME, host, strlen(host) + 1);
 		if (ret < 0) {
 			return -errno;
 		}


### PR DESCRIPTION
`zsock_setsockopt()` expects to receive `NULL` terminated string and length of
the string **including** `NULL` termination. Adjust code to follow that.

See Zephyr upstream commit 4234e801b544 ("net: sockets: Fix TLS_HOSTNAME
option length inconsistency") for details.