### PR TITLE
west-zephyr: import all Zephyr modules

### DIFF
--- a/.ci-west-zephyr.yml
+++ b/.ci-west-zephyr.yml
@@ -1,0 +1,17 @@
+manifest:
+  self:
+    path: modules/lib/golioth
+    import:
+      file: west-zephyr.yml
+      name-allowlist:
+        - cmsis
+        - hal_espressif
+        - hal_nordic
+        - hal_nxp
+        - mbedtls
+        - mcuboot
+        - net-tools
+        - qcbor
+        - segger
+        - tinycrypt
+        - zephyr

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -28,7 +28,7 @@ jobs:
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth
-          file = west-zephyr.yml
+          file = .ci-west-zephyr.yml
           EOF
 
           west update -o=--depth=1 -n

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -24,7 +24,7 @@ jobs:
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth
-          file = west-zephyr.yml
+          file = .ci-west-zephyr.yml
           EOF
 
           west update -o=--depth=1 -n zephyr

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -31,7 +31,7 @@ jobs:
           cat <<EOF > .west/config
           [manifest]
           path = modules/lib/golioth
-          file = west-zephyr.yml
+          file = .ci-west-zephyr.yml
           EOF
 
           west update -o=--depth=1 -n

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 image: zephyrprojectrtos/ci:v0.24.2
 
 variables:
-  WEST_MANIFEST: west-zephyr.yml
+  WEST_MANIFEST: .ci-west-zephyr.yml
 
 .west-init: &west-init
   - rm -rf .west modules/lib/golioth

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -4,17 +4,7 @@ manifest:
       revision: v3.3.0
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
-      import:
-        name-allowlist:
-          - cmsis
-          - hal_espressif
-          - hal_nordic
-          - hal_nxp
-          - mbedtls
-          - mcuboot
-          - net-tools
-          - segger
-          - tinycrypt
+      import: true
 
   self:
     path: modules/lib/golioth


### PR DESCRIPTION
In case of `west-zephyr.yml` there is a name-allowlist filter, while in case
of `west-ncs.yml` there is no such filter. This makes filtering logic
inconsistent across Zephyr vanilla vs NCS.

Limiting repositories has a major flaw when user wants to utilize a generic
library such as picolibc, which is filtered out. In that case it is needed
to add that repository to downstream manifest or temporarily modify
`west-zephyr.yml` in order to test some non-standard configuration with SDK
samples.

Let's be consistent about Zephyr modules filtering and always import all
the modules in `west-zephyr.yml`, just like it happens with `west-ncs.yml`.

Since limiting `west-zephyr.yml` was mainly a clone time improvement,
noticeable in CI, add .ci-`west-zephyr.yml` which will limit repositories
just for being run in CI.