### PR TITLE
samples: dfu: override esp_clk_init() with empty definition

### DIFF
--- a/samples/dfu/CMakeLists.txt
+++ b/samples/dfu/CMakeLists.txt
@@ -7,3 +7,5 @@ project(dfu)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOOTLOADER_MCUBOOT app PRIVATE src/flash.c)
+
+target_sources_ifdef(CONFIG_ESP_CLK_INIT_OVERRIDE app PRIVATE src/esp_clk_init.c)

--- a/samples/dfu/Kconfig
+++ b/samples/dfu/Kconfig
@@ -26,4 +26,18 @@ config GOLIOTH_SAMPLE_SETTINGS_SHELL
 
 endif # SETTINGS
 
+if HAS_ESPRESSIF_HAL
+
+config ESP_CLK_INIT_OVERRIDE
+	bool "Override ESP clock initialization"
+	default y
+	help
+	  Override weak ESP clock initialization `void esp_clk_init(void)` with
+	  empty definition.
+
+	  Enable this option when experiencing issues booting application after
+	  swap.
+
+endif # HAS_ESPRESSIF_HAL
+
 source "Kconfig.zephyr"

--- a/samples/dfu/src/esp_clk_init.c
+++ b/samples/dfu/src/esp_clk_init.c
@@ -1,0 +1,4 @@
+/* Override weak function in hal_espressif */
+void esp_clk_init(void)
+{
+}


### PR DESCRIPTION
There is an issue when booting new firmware for the first time. This
results in boot hang. It seems that the reason is `esp_clk_init()`.
Fortunately this function definition is flagged as weak, so override it in
sample to make DFU functional.