### PR TITLE
samples: rpc: log during method invocations

### DIFF
--- a/samples/rpc/src/main.c
+++ b/samples/rpc/src/main.c
@@ -33,7 +33,11 @@ static enum golioth_rpc_status on_multiply(QCBORDecodeContext *request_params_ar
 	}
 
 	value = a * b;
+
+	LOG_DBG("%lf * %lf = %lf", a, b, value);
+
 	QCBOREncode_AddDoubleToMap(response_detail_map, "value", value);
+
 	return GOLIOTH_RPC_OK;
 }
 


### PR DESCRIPTION
Right now this sample was silent on the Zephyr console, so the only way to
tell whether RPC was executed was using REST API and/or web console. This
however does not tell whether tested board was the one responding with
correct results.

Add debug logs, so that every RPC invocation results in clear notification
on Zephyr console.