### PR TITLE
Allow loading PSK-ID's longer than 64 chars from settings 

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -299,6 +299,13 @@ config GOLIOTH_SYSTEM_SETTINGS
 	  When selected, Golioth credentials will be loaded from settings
 	  subsystem.
 
+config GOLIOTH_PSK_ID_MAX_LEN
+	int "Maximum Lenght of the PSK-ID stored in settings"
+	depends on GOLIOTH_SYSTEM_SETTINGS
+	default 128 
+	help
+	  Sets the maximum length of the PSK-ID stored in settings
+
 endif # GOLIOTH_SYSTEM_CLIENT
 
 endif # GOLIOTH

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -477,7 +477,7 @@ void golioth_system_client_stop(void)
  */
 static uint8_t golioth_dtls_psk[PSK_MAX_LEN];
 static size_t golioth_dtls_psk_len;
-static uint8_t golioth_dtls_psk_id[64];
+static uint8_t golioth_dtls_psk_id[GOLIOTH_PSK_ID_MAX_LEN];
 static size_t golioth_dtls_psk_id_len;
 
 static void golioth_settings_check_credentials(void)


### PR DESCRIPTION
I have been testing out the various features of the Golioth SDK and console. When testing the `'samples/settings'` project I ran into an issue (`net_sock_tls: TLS handshake error: -7780`) when the system client was trying to connect to the Golioth servers .  

After debugging the issue, the root cause is that golioth_dtls_psk_id ([in system_client.c](https://github.com/golioth/golioth-zephyr-sdk/blob/ff8de0da412680d8c8e3ca082369fda2f71a99ad/net/golioth/system_client.c#L480))  is only set to allow PSK-ID's with a max length of 64 chars.

This fix is needed because 'console.golioth.io' will auto-generate and allow psk-id's over 64 chars.