### PR TITLE
coap_req: fix log format for 'size_t'

### DIFF
--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -254,7 +254,7 @@ static int golioth_coap_req_reply_handler(struct golioth_coap_req *req,
 				.err = -EBADMSG,
 			};
 
-			LOG_ERR("Failed to move to next block: %d", new_offset);
+			LOG_ERR("Failed to move to next block: %zu", new_offset);
 
 			(void)req->cb(&rsp);
 


### PR DESCRIPTION
Use `%zu` instead of `%d` for printing `size_t new_offset` variable. This
suppresses build time warnings for `qemu_x86_64` platform:

```
coap_req.c:257:33: warning: format '%d' expects argument of type 'int', \
  but argument 2 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]

```