### PR TITLE
golioth: remove 'client->rx_options'

### DIFF
--- a/include/net/golioth.h
+++ b/include/net/golioth.h
@@ -57,7 +57,6 @@ struct golioth_client {
 	size_t rx_received;
 
 	struct coap_packet rx_packet;
-	struct coap_option rx_options[CONFIG_GOLIOTH_COAP_MAX_OPTIONS];
 
 	struct k_mutex lock;
 	int sock;

--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -113,12 +113,6 @@ config GOLIOTH_CIPHERSUITES
 	  If empty, then underlying TLS implementation (e.g. mbedTLS library) decides which
 	  ciphersuites to use. Relying on that is not recommended!
 
-config GOLIOTH_COAP_MAX_OPTIONS
-	int "Maximum CoAP options supported"
-	default 16
-	help
-	  Maximum CoAP options supported by Golioth client.
-
 config GOLIOTH_FW
 	bool "Firmware management"
 	select QCBOR

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -464,8 +464,7 @@ static int golioth_process_rx_data(struct golioth_client *client,
 	uint8_t type;
 
 	err = coap_packet_parse(&client->rx_packet, data, len,
-				client->rx_options,
-				ARRAY_SIZE(client->rx_options));
+				NULL, 0);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
This member was never used. Since `coap_packet_parse()` handles passing `NULL`
pointer, use that instead of storing received CoAP options.