### PR TITLE
scripts: python: DFU (Artifacts/Release) + State/Stream Monitoring

### DIFF
--- a/scripts/python/golioth/golioth/__init__.py
+++ b/scripts/python/golioth/golioth/__init__.py
@@ -14,6 +14,10 @@ from .golioth import (
     DeviceLightDB,
     DeviceRPC,
     Certificate,
+    Artifact,
+    Release,
+    ProjectArtifacts,
+    ProjectReleases,
     ProjectCertificates,
     ProjectSettings,
 )

--- a/scripts/python/golioth/golioth/__init__.py
+++ b/scripts/python/golioth/golioth/__init__.py
@@ -13,6 +13,7 @@ from .golioth import (
     LogEntry,
     Device,
     DeviceLightDB,
+    DeviceStream,
     DeviceRPC,
     Certificate,
     Artifact,

--- a/scripts/python/golioth/golioth/__init__.py
+++ b/scripts/python/golioth/golioth/__init__.py
@@ -11,6 +11,7 @@ from .golioth import (
     LogLevel,
     LogEntry,
     Device,
+    DeviceLightDB,
     DeviceRPC,
     ProjectSettings,
 )

--- a/scripts/python/golioth/golioth/__init__.py
+++ b/scripts/python/golioth/golioth/__init__.py
@@ -6,6 +6,7 @@ from .golioth import (
     RPCResultError,
     RPCTimeout,
     Client,
+    LightDBMonitor,
     LogsMonitor,
     Project,
     LogLevel,

--- a/scripts/python/golioth/golioth/__init__.py
+++ b/scripts/python/golioth/golioth/__init__.py
@@ -13,5 +13,7 @@ from .golioth import (
     Device,
     DeviceLightDB,
     DeviceRPC,
+    Certificate,
+    ProjectCertificates,
     ProjectSettings,
 )

--- a/scripts/python/golioth/golioth/cli.py
+++ b/scripts/python/golioth/golioth/cli.py
@@ -402,6 +402,28 @@ async def monitor(config, device_name, path):
 
 
 @cli.group()
+def stream():
+    """LightDB Stream related commands."""
+    pass
+
+
+@stream.command()
+@click.option('-d', '--device-name',
+              help='Name of device',
+              required=True)
+@pass_config
+async def monitor(config, device_name):
+    """Monitor LightDB Stream."""
+    with console.status('Monitoring LightDB Stream path...'):
+        client = Client(config.config_path, api_key=config.api_key)
+        project = await client.default_project()
+        device = await project.device_by_name(device_name)
+
+        async for value in device.stream.iter():
+            console.print(value)
+
+
+@cli.group()
 def certificate():
     """Certificates related commands."""
     pass

--- a/scripts/python/golioth/golioth/cli.py
+++ b/scripts/python/golioth/golioth/cli.py
@@ -382,6 +382,25 @@ async def delete(config, device_name, path):
         await device.lightdb.delete(path)
 
 
+@lightdb.command()
+@click.option('-d', '--device-name',
+              help='Name of device',
+              required=True)
+@click.argument('path')
+@pass_config
+async def monitor(config, device_name, path):
+    """Monitor LightDB State path."""
+    path = path.strip('/')
+
+    with console.status('Monitoring LightDB State path...'):
+        client = Client(config.config_path, api_key=config.api_key)
+        project = await client.default_project()
+        device = await project.device_by_name(device_name)
+
+        async for value in device.lightdb.iter(path):
+            console.print(value)
+
+
 @cli.group()
 def certificate():
     """Certificates related commands."""

--- a/scripts/python/golioth/golioth/golioth.py
+++ b/scripts/python/golioth/golioth/golioth.py
@@ -292,9 +292,12 @@ class LogEntry:
         return self.info['module']
 
     @property
+    def type(self) -> str:
+        return self.info['type']
+
+    @property
     def metadata(self) -> dict:
         return self.info['metadata']
-
 
 class Device(ApiNodeMixin):
     def __init__(self, project: Project, info: dict[str, Any]):


### PR DESCRIPTION
There are various new CLI commands implemented:

 * `golioth artifacts upload -rrf build/zephyr/zephyr.bin`

   All in one go:
   - automatically figure out version from MCUboot signature metadata (from `zephyr.signed.bin`
     images)
   - upload an artifact with this version
   - create a release with version as a release-tag (first `-r` flag)
   - rollout firmware (second `-r` flag)
   - remove any conflicting artifacts/releases (with the same version/release-tag) if they were
     previously existing (`-f` flag)

 * `golioth artifacts delete '*'`

   Delete all artifacts.

 * `golioth artifacts list`

   List all artifacts.

 * `golioth releases delete '*'`

   Delete all releases.

 * `golioth releases list`

   List all releases.

 * `golioth lightdb monitor -d DEVICE_NAME /counter`

   Monitor `/counter` in LightDB State

 * `golioth stream monitor -d DEVICE_NAME`
 
   Monitor LightDB Stream events.

Additionally there are corresponding Python library interfaces, which will be useful for Pytest
scripts testing `tests/` and `samples/`.