### PR TITLE
ci: update Zephyr CI image to v0.26.1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.24.2
+      image: zephyrprojectrtos/ci:v0.26.1
 
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.24.2
+      image: zephyrprojectrtos/ci:v0.26.1
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: zephyrprojectrtos/ci:v0.24.2
+      image: zephyrprojectrtos/ci:v0.26.1
 
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: zephyrprojectrtos/ci:v0.24.2
+image: zephyrprojectrtos/ci:v0.26.1
 
 variables:
   WEST_MANIFEST: .ci-west-zephyr.yml


### PR DESCRIPTION
This updates Zephyr SDK version to 0.16.0.