### PR TITLE
docs: update all links to Zephyr docs to v3.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,8 +156,8 @@ During release testing, all boards and services are verified using sample applic
 +------------------+--------------+-------------+----------+
 
 .. _Zephyr RTOS: https://www.zephyrproject.org/
-.. _west: https://docs.zephyrproject.org/3.0.0/guides/west/index.html
-.. _Zephyr Getting Started: https://docs.zephyrproject.org/3.0.0/getting_started/index.html
+.. _west: https://docs.zephyrproject.org/3.3.0/develop/west/index.html
+.. _Zephyr Getting Started: https://docs.zephyrproject.org/3.3.0/develop/getting_started/index.html
 .. _nRF Connect SDK: https://www.nordicsemi.com/Software-and-tools/Software/nRF-Connect-SDK
 .. _nRF Connect SDK Getting Started: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html
 .. _nRF9160 Feather: https://www.jaredwolff.com/store/nrf9160-feather/

--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -327,7 +327,7 @@ running from primary area (first application slot):
      copy done: unset
      image ok: unset
 
-.. _MCUboot: https://docs.zephyrproject.org/3.0.0/guides/device_mgmt/dfu.html#mcuboot
-.. _Signing Binaries: https://docs.zephyrproject.org/3.0.0/guides/west/sign.html#west-sign
-.. _Flash map: https://docs.zephyrproject.org/3.0.0/reference/storage/flash_map/flash_map.html#flash-map-api
+.. _MCUboot: https://docs.zephyrproject.org/3.3.0/services/device_mgmt/dfu.html#mcuboot
+.. _Signing Binaries: https://docs.zephyrproject.org/3.3.0/develop/west/sign.html#west-sign
+.. _Flash map: https://docs.zephyrproject.org/3.3.0/services/storage/flash_map/flash_map.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -188,6 +188,6 @@ This is the output from the serial console:
 Responses to Hello messages are printed above as a hexdump of "Hello mark". This
 means that communication with Golioth is working.
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -168,6 +168,6 @@ This is the output from the serial console:
    [00:04:14.181,000] <inf> golioth_system: Client connected!
    [00:04:14.898,000] <inf> golioth_system: Disconnect request
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/delete/README.rst
+++ b/samples/lightdb/delete/README.rst
@@ -174,6 +174,6 @@ The value can be set with:
    goliothctl lightdb set <device-name> /counter -b "{\"counter\":34}"
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/get/README.rst
+++ b/samples/lightdb/get/README.rst
@@ -180,6 +180,6 @@ The value can be set with:
    goliothctl lightdb set <device-name> /counter -b 12
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -174,6 +174,6 @@ retrieves it every time that it's updated. The value can be updates as such:
    goliothctl lightdb set <device-name> /counter -b 12
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/set/README.rst
+++ b/samples/lightdb/set/README.rst
@@ -179,6 +179,6 @@ with its value. Current value can be fetched using following command:
    goliothctl lightdb get <device-name> /counter
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -195,6 +195,6 @@ as:
 - ``/aliases/led3``
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb_stream/README.rst
+++ b/samples/lightdb_stream/README.rst
@@ -257,6 +257,6 @@ Historical data can be queried using following command:
    ]
 
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/logging/README.rst
+++ b/samples/logging/README.rst
@@ -198,6 +198,6 @@ This is how logs are visible
    [2021-04-08 14:20:32 +0000 UTC] level:DEBUG module:"golioth_logging" message:"Log 2: 0" metadata:{fields:{key:"func" value:{string_value:"func_2"}} fields:{key:"index" value:{number_value:8}} fields:{key:"uptime" value:{number_value:100000}}} device_id:"xxxxxxxxxxxxxxxxxxxxxxxx"
    [2021-04-08 14:20:32 +0000 UTC] level:DEBUG module:"golioth_logging" message:"Log 1: 0" metadata:{fields:{key:"func" value:{string_value:"func_1"}} fields:{key:"index" value:{number_value:7}} fields:{key:"uptime" value:{number_value:100000}}} device_id:"xxxxxxxxxxxxxxxxxxxxxxxx"
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
-.. _ESP32: https://docs.zephyrproject.org/3.0.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html
+.. _ESP32: https://docs.zephyrproject.org/3.3.0/boards/xtensa/esp32/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/tests/lightdb/README.rst
+++ b/tests/lightdb/README.rst
@@ -34,4 +34,4 @@ Run ``twister``:
 
    zephyr/scripts/twister -p qemu_x86 -T modules/lib/golioth/tests/lightdb
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.0.0/guides/networking/qemu_setup.html#networking-with-qemu
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.3.0/connectivity/networking/qemu_setup.html


### PR DESCRIPTION
All links were pointing to Zephyr 3.0.0. Since we support Zephyr 3.3.0,
provide links to that version of docs.