### PR TITLE
samples: dfu: disable settings in system client for vanilla Zephyr tests

### DIFF
--- a/samples/dfu/sample.yaml
+++ b/samples/dfu/sample.yaml
@@ -15,6 +15,8 @@ tests:
     platform_allow: >
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+    extra_args:
+      dfu_CONFIG_GOLIOTH_SYSTEM_SETTINGS=n
   sample.golioth.dfu.ncs:
     platform_allow: nrf9160dk_nrf9160_ns
     harness_config:


### PR DESCRIPTION
Disable settings support in system client, so that PSK-ID and PSK will be
pulled in from environment variables and baked into the firmware. This
allows to omit credentials provisioning.

This is a follow-up of commit 6f1e59270834 ("samples: dfu: disable settings
in system client for NCS runtime test").