### PR TITLE
samples: dfu: pytest: convert os.path.* to pathlib

### DIFF
--- a/samples/dfu/pytest/test_sample.py
+++ b/samples/dfu/pytest/test_sample.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 import logging
 from operator import attrgetter
 import os


### PR DESCRIPTION
Convert all `os.path.*` invocations to `pathlib`, in order to improve code
readability and consistency.