### PR TITLE
samples: introduce GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT

### DIFF
--- a/samples/common/Kconfig
+++ b/samples/common/Kconfig
@@ -73,4 +73,14 @@ config GOLIOTH_SAMPLE_WIFI_PSK
 
 endif # GOLIOTH_SAMPLE_WIFI && !GOLIOTH_SAMPLE_WIFI_SETTINGS
 
+config GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT
+	int "Test connect timeout"
+	default 120 if NRF_MODEM_LIB
+	default 30
+	help
+	  Connect timeout used by Pytest scripts to wait for initial
+	  connection/communication with DUT.
+
+	  Not used by the sample code itself.
+
 endif # GOLIOTH_SAMPLES_COMMON

--- a/samples/dfu/pytest/conftest.py
+++ b/samples/dfu/pytest/conftest.py
@@ -1,9 +1,20 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[3]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
+
+PROJECT_NAME = "dfu"
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +26,22 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def build_conf(cmdopt):
+    if (Path(cmdopt) / "pm.config").is_file():
+        return BuildConfiguration(cmdopt)
+    elif (Path(cmdopt) / PROJECT_NAME).is_dir():
+        return BuildConfiguration(str(Path(cmdopt) / PROJECT_NAME))
+
+    raise RuntimeError("Unsupported build directory structure")
+
+@pytest.fixture(scope='session')
+def initial_timeout(build_conf):
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/dfu/pytest/test_sample.py
+++ b/samples/dfu/pytest/test_sample.py
@@ -19,17 +19,8 @@ import trio
 pytestmark = pytest.mark.anyio
 
 
-DEFAULT_TIMEOUT = 30
 PROJECT_NAME = "dfu"
 NEW_VERSION = "2.0.0"
-
-
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
 
 
 @pytest.fixture(scope='session')

--- a/samples/dfu/sample.yaml
+++ b/samples/dfu/sample.yaml
@@ -19,7 +19,5 @@ tests:
       dfu_CONFIG_GOLIOTH_SYSTEM_SETTINGS=n
   sample.golioth.dfu.ncs:
     platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_GOLIOTH_SYSTEM_SETTINGS=n

--- a/samples/lightdb/delete/pytest/conftest.py
+++ b/samples/lightdb/delete/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[4]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb/delete/pytest/test_sample.py
+++ b/samples/lightdb/delete/pytest/test_sample.py
@@ -17,14 +17,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/lightdb/delete/sample.yaml
+++ b/samples/lightdb/delete/sample.yaml
@@ -5,19 +5,13 @@ common:
   harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
-  sample.golioth.lightdb_delete.fast:
+  sample.golioth.lightdb_delete:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y
-      - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
-  sample.golioth.lightdb_delete.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_LOG_BACKEND_GOLIOTH=y
       - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048

--- a/samples/lightdb/get/pytest/conftest.py
+++ b/samples/lightdb/get/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[4]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb/get/pytest/test_sample.py
+++ b/samples/lightdb/get/pytest/test_sample.py
@@ -18,14 +18,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/lightdb/get/sample.yaml
+++ b/samples/lightdb/get/sample.yaml
@@ -5,19 +5,13 @@ common:
   harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
-  sample.golioth.lightdb_get.fast:
+  sample.golioth.lightdb_get:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y
-      - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
-  sample.golioth.lightdb_get.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_LOG_BACKEND_GOLIOTH=y
       - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048

--- a/samples/lightdb/observe/pytest/conftest.py
+++ b/samples/lightdb/observe/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[4]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb/observe/pytest/test_sample.py
+++ b/samples/lightdb/observe/pytest/test_sample.py
@@ -18,14 +18,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/lightdb/observe/sample.yaml
+++ b/samples/lightdb/observe/sample.yaml
@@ -5,19 +5,13 @@ common:
   harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
-  sample.golioth.lightdb_observe.fast:
+  sample.golioth.lightdb_observe:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y
-      - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
-  sample.golioth.lightdb_observe.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_LOG_BACKEND_GOLIOTH=y
       - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048

--- a/samples/lightdb/set/pytest/conftest.py
+++ b/samples/lightdb/set/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[4]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb/set/pytest/test_sample.py
+++ b/samples/lightdb/set/pytest/test_sample.py
@@ -17,14 +17,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/lightdb/set/sample.yaml
+++ b/samples/lightdb/set/sample.yaml
@@ -5,19 +5,13 @@ common:
   harness: pytest
   tags: golioth lightdb socket goliothd
 tests:
-  sample.golioth.lightdb_set.fast:
+  sample.golioth.lightdb_set:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y
-      - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
-  sample.golioth.lightdb_set.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_LOG_BACKEND_GOLIOTH=y
       - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048

--- a/samples/lightdb_led/pytest/conftest.py
+++ b/samples/lightdb_led/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[3]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb_led/pytest/test_sample.py
+++ b/samples/lightdb_led/pytest/test_sample.py
@@ -19,14 +19,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/lightdb_led/sample.yaml
+++ b/samples/lightdb_led/sample.yaml
@@ -5,19 +5,13 @@ common:
   harness: pytest
   tags: golioth socket goliothd
 tests:
-  sample.golioth.lightdb_led.fast:
+  sample.golioth.lightdb_led:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y
-      - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
-  sample.golioth.lightdb_led.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]
     extra_configs:
       - CONFIG_LOG_BACKEND_GOLIOTH=y
       - CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048

--- a/samples/lightdb_stream/pytest/conftest.py
+++ b/samples/lightdb_stream/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[3]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/lightdb_stream/pytest/test_sample.py
+++ b/samples/lightdb_stream/pytest/test_sample.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from contextlib import suppress
-import json
 import logging
 import os
 
@@ -17,14 +15,6 @@ pytestmark = pytest.mark.anyio
 
 
 DEFAULT_TIMEOUT = 30
-
-
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
 
 
 @pytest.fixture(scope='session')

--- a/samples/lightdb_stream/sample.yaml
+++ b/samples/lightdb_stream/sample.yaml
@@ -5,13 +5,10 @@ common:
   harness: pytest
   tags: golioth socket goliothd
 tests:
-  sample.golioth.lightdb_stream.fast:
+  sample.golioth.lightdb_stream:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-  sample.golioth.lightdb_stream.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]

--- a/samples/logging/pytest/conftest.py
+++ b/samples/logging/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[3]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/logging/pytest/test_sample.py
+++ b/samples/logging/pytest/test_sample.py
@@ -21,14 +21,6 @@ pytestmark = pytest.mark.anyio
 DEFAULT_TIMEOUT = 30
 
 
-@pytest.fixture()
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device():
     client = Client(os.environ.get("GOLIOTHCTL_CONFIG"))

--- a/samples/logging/sample.yaml
+++ b/samples/logging/sample.yaml
@@ -5,13 +5,10 @@ common:
   harness: pytest
   tags: golioth logger socket goliothd
 tests:
-  sample.golioth.logging.fast:
+  sample.golioth.logging:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-  sample.golioth.logging.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]

--- a/samples/rpc/pytest/conftest.py
+++ b/samples/rpc/pytest/conftest.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2020 Intel Corporation.
-# Copyright (c) 2022 Golioth, Inc.
+# Copyright (c) 2022-2023 Golioth, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
+import sys
+
 import pytest
+
+GOLIOTH_BASE = Path(__file__).resolve().parents[3]
+ZEPHYR_BASE = GOLIOTH_BASE.parents[2] / 'zephyr'
+
+sys.path.insert(0, str(ZEPHYR_BASE / 'scripts' / 'west_commands'))
+from runners.core import BuildConfiguration
 
 @pytest.fixture(scope='session')
 def anyio_backend():
@@ -15,12 +24,15 @@ def pytest_addoption(parser):
     parser.addoption(
         '--cmdopt'
     )
-    parser.addoption(
-        '--initial-timeout', type=int
-    )
 
 # define fixture to return value of option "--cmdopt", this fixture
 # will be requested by other fixture of tests.
-@pytest.fixture()
+@pytest.fixture(scope='session')
 def cmdopt(request):
     return request.config.getoption('--cmdopt')
+
+@pytest.fixture(scope='session')
+def initial_timeout(cmdopt):
+    build_conf = BuildConfiguration(cmdopt)
+
+    return build_conf['CONFIG_GOLIOTH_SAMPLE_TEST_CONNECT_TIMEOUT']

--- a/samples/rpc/pytest/test_sample.py
+++ b/samples/rpc/pytest/test_sample.py
@@ -15,17 +15,6 @@ from trio import sleep
 pytestmark = pytest.mark.anyio
 
 
-DEFAULT_TIMEOUT = 30
-
-
-@pytest.fixture(scope='session')
-def initial_timeout(request):
-    timeout = request.config.getoption('--initial-timeout')
-    if timeout is None:
-        timeout = DEFAULT_TIMEOUT
-    return timeout
-
-
 @pytest.fixture(scope='session')
 async def device(initial_timeout):
     device_name = os.environ["GOLIOTH_DEVICE_NAME"]

--- a/samples/rpc/sample.yaml
+++ b/samples/rpc/sample.yaml
@@ -5,13 +5,10 @@ common:
   harness: pytest
   tags: golioth socket goliothd
 tests:
-  sample.golioth.rpc.fast:
+  sample.golioth.rpc:
     platform_allow: >
       esp32
       mimxrt1060_evkb
       nrf52840dk_nrf52840
+      nrf9160dk_nrf9160_ns
       qemu_x86
-  sample.golioth.rpc.long_start:
-    platform_allow: nrf9160dk_nrf9160_ns
-    harness_config:
-      pytest_args: [ "--initial-timeout", "120" ]


### PR DESCRIPTION
Introduce connect timeout as a build configuration, so that test scripts
will know how much time to wait before considering connection timeout.
Having it as Kconfig option allows to configure it per platform and per
connectivity requirements.

This replaces custom `--initial-timeout` pytest argument, which resulted in
duplicating test cases for fast (default 30s) / long (configured 120s)
timeouts.