### PR TITLE
samples: dfu: pytest: reduce hardcoded global variables

### DIFF
--- a/samples/dfu/pytest/test_sample.py
+++ b/samples/dfu/pytest/test_sample.py
@@ -19,7 +19,7 @@ import trio
 pytestmark = pytest.mark.anyio
 
 
-PROJECT_NAME = "dfu"
+PROJECT_NAME = Path(__file__).parents[1].name
 NEW_VERSION = "2.0.0"
 
 


### PR DESCRIPTION
Remove one hardcoded `dfu` project name in order to be able to quickly
move (copy-paste) this test to other directory/sample.

Do not hardcode new firmware version (`2.0.0`) globally and move it into the
test itself. This will allow to develop more DFU tests, that allow to test
a flow with multiple rollouts (thus multiple versions).

Introduce a `Firmware` helper class, which will store both the path and the
version of the firmware. Use `imgtool` package in order to figure out the
version automatically from file name (in the context where only a firmware
object is passed).