### PR TITLE
net: golioth: Kconfig for max CBOR RPC response

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -134,6 +134,15 @@ config GOLIOTH_RPC_MAX_NUM_METHODS
 	  Maximum number of Golioth Remote Procedure Call methods that can
 	  be registered.
 
+config GOLIOTH_RPC_MAX_RESPONSE_LEN
+	int "Maximum length of the CBOR response"
+	depends on GOLIOTH_RPC
+	default 256
+	help
+	  Maximum length of the CBOR response returned by Golioth RPC methods.
+	  If this value is too small for the returned package, a
+	  QCBOR_ERR_BUFFER_TOO_SMALL will occur.
+
 config GOLIOTH_SETTINGS
 	bool "Settings cloud service"
 	select QCBOR

--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -38,7 +38,6 @@ LOG_MODULE_DECLARE(golioth);
 
 #define GOLIOTH_RPC_PATH ".rpc"
 #define GOLIOTH_RPC_STATUS_PATH ".rpc/status"
-#define GOLIOTH_RPC_MAX_RESPONSE_LEN 256
 
 static int send_response(struct golioth_client *client,
 			 uint8_t *coap_payload, size_t coap_payload_len)
@@ -87,7 +86,7 @@ static int on_rpc(struct golioth_req_rsp *rsp)
 	}
 
 	/* Start encoding response */
-	uint8_t response_buf[GOLIOTH_RPC_MAX_RESPONSE_LEN];
+	uint8_t response_buf[CONFIG_GOLIOTH_RPC_MAX_RESPONSE_LEN];
 	UsefulBuf response_bufc = { response_buf, sizeof(response_buf) };
 	QCBOREncodeContext encode_ctx;
 


### PR DESCRIPTION
Introduce GOLIOTH_RPC_MAX_RESPONSE_LEN which allows applications to change the max size of the CBOR response returned from an RPC method. This solves
the issue of receiving an error when the RPC response is too large: <err>
golioth: QCBOREncode_FinishGetSize error: 1 (QCBOR_ERR_BUFFER_TOO_SMALL)