### PR TITLE
gitlab-ci: remove remaining `west forall ...` invocations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,6 @@ cache-deps:
     <<: *cache-deps
     policy: pull-push
   script:
-    - west forall -c 'git clean -ffdx && git reset --hard'
     - rm -rf modules/lib/golioth
   only:
     refs:
@@ -67,10 +66,7 @@ checkpatch:
     - *west-init
     - west update modules/lib/golioth
     - >
-      west update zephyr -o=--depth=1 -n ||
-      (west forall -c 'git clean -ffdx && git reset --hard' &&
-       west update zephyr -o=--depth=1 -n)
-    - west forall -c 'git clean -ffdx && git reset --hard'
+      west update zephyr -o=--depth=1 -n
   script:
     - cd modules/lib/golioth
     - git fetch


### PR DESCRIPTION
Don't issue `west forall -c ...` to cleanup west projects, as they should
no longer contain unstaged changes.

Fixes: a93f9f13dc46 ("ci: replace 'git apply' with 'git am' when applying patches")