### PR TITLE
samples: hello: fix auth cert symbol format

### DIFF
--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -48,8 +48,8 @@ by adding these lines to configuration file (e.g. ``prj.conf``):
 .. code-block:: cfg
 
    CONFIG_GOLIOTH_AUTH_METHOD_CERT=y
-   CONFIG_GOLIOTH_SYSTEM_CLIENT_CRT_PATH='"keys/device.crt.der"'
-   CONFIG_GOLIOTH_SYSTEM_CLIENT_KEY_PATH='"keys/device.key.der"'
+   CONFIG_GOLIOTH_SYSTEM_CLIENT_CRT_PATH="keys/device.crt.der"
+   CONFIG_GOLIOTH_SYSTEM_CLIENT_KEY_PATH="keys/device.key.der"
 
 Platform specific configuration
 ===============================


### PR DESCRIPTION
An extra set of single quotes in the Kconfig symbol for certificate authentication has been removed to prevent a build warning that is causing the symbols to be ignored:

warning: malformed string literal in assignment to GOLIOTH_SYSTEM_CLIENT_CRT_PATH