### PR TITLE
kconfig: add options for maximum PSK-ID and PSK lengths

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -310,6 +310,23 @@ config GOLIOTH_SYSTEM_SETTINGS
 	  When selected, Golioth credentials will be loaded from settings
 	  subsystem.
 
+if GOLIOTH_SYSTEM_SETTINGS
+
+config GOLIOTH_SYSTEM_CLIENT_PSK_ID_MAX_LEN
+	int "Max length of PSK ID"
+	default 64
+	help
+	  Maximum length of PSK ID, in bytes.
+
+config GOLIOTH_SYSTEM_CLIENT_PSK_MAX_LEN
+	int "Max length of PSK"
+	default MBEDTLS_PSK_MAX_LEN if MBEDTLS_BUILTIN
+	default 64
+	help
+	  Maximum length of PSK, in bytes.
+
+endif # GOLIOTH_SYSTEM_SETTINGS
+
 endif # GOLIOTH_SYSTEM_CLIENT
 
 endif # GOLIOTH

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -475,9 +475,9 @@ void golioth_system_client_stop(void)
  * credentials are stored. This means that we need to allocate memory for
  * credentials ourselves.
  */
-static uint8_t golioth_dtls_psk[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_MAX_LEN];
+static uint8_t golioth_dtls_psk[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_MAX_LEN + 1];
 static size_t golioth_dtls_psk_len;
-static uint8_t golioth_dtls_psk_id[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_ID_MAX_LEN];
+static uint8_t golioth_dtls_psk_id[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_ID_MAX_LEN + 1];
 static size_t golioth_dtls_psk_id_len;
 
 static void golioth_settings_check_credentials(void)
@@ -550,6 +550,12 @@ static int golioth_settings_set(const char *name, size_t len_rd,
 	if (ret < 0) {
 		LOG_ERR("Failed to read value: %d", (int) ret);
 		return ret;
+	}
+
+	if (ret >= buffer_len) {
+		LOG_ERR("Configured %s does not fit into (%zu bytes) static buffer!",
+			name, buffer_len - 1);
+		return -ENOMEM;
 	}
 
 	*value_len = ret;

--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -31,16 +31,10 @@ LOG_MODULE_REGISTER(golioth_system, CONFIG_GOLIOTH_SYSTEM_CLIENT_LOG_LEVEL);
 #define TLS_PSK			""
 #endif
 
-#ifdef CONFIG_MBEDTLS_PSK_MAX_LEN
-#define PSK_MAX_LEN		CONFIG_MBEDTLS_PSK_MAX_LEN
+#if defined(CONFIG_MBEDTLS_BUILTIN) && defined(CONFIG_MBEDTLS_PSK_MAX_LEN) && \
+	!defined(CONFIG_GOLIOTH_SYSTEM_SETTINGS)
 BUILD_ASSERT(sizeof(TLS_PSK) - 1 <= CONFIG_MBEDTLS_PSK_MAX_LEN,
 	     "PSK exceeds mbedTLS configured maximum PSK length");
-#else
-/*
- * Support NCS mirror of Zephyr, which does not have CONFIG_MBEDTLS_PSK_MAX_LEN
- * defined yet.
- */
-#define PSK_MAX_LEN		64
 #endif
 
 static const uint8_t tls_ca_crt[] = {
@@ -481,9 +475,9 @@ void golioth_system_client_stop(void)
  * credentials are stored. This means that we need to allocate memory for
  * credentials ourselves.
  */
-static uint8_t golioth_dtls_psk[PSK_MAX_LEN];
+static uint8_t golioth_dtls_psk[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_MAX_LEN];
 static size_t golioth_dtls_psk_len;
-static uint8_t golioth_dtls_psk_id[64];
+static uint8_t golioth_dtls_psk_id[CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_ID_MAX_LEN];
 static size_t golioth_dtls_psk_id_len;
 
 static void golioth_settings_check_credentials(void)


### PR DESCRIPTION
PSK-ID length was always hardcoded to maximum 64 characters. As a result
long project names with long PSK-IDs (due to
`long-device-id@long-project-name` PSK-ID format) would not be supported.

PSK had the same issue, but only when used with NCS.

Introduce options for both, PSK-ID and PSK, so that long credentials can be
supported without changing SDK codebase.

Alternative to: #359 