### PR TITLE
rpc: verify length of method name

### DIFF
--- a/net/golioth/rpc.c
+++ b/net/golioth/rpc.c
@@ -102,7 +102,8 @@ static int on_rpc(struct golioth_req_rsp *rsp)
 	for (int i = 0; i < client->rpc.num_methods; i++) {
 		const struct golioth_rpc_method *method = &client->rpc.methods[i];
 
-		if (strncmp(method->name, method_buf.ptr, method_buf.len) == 0) {
+		if (strlen(method->name) == method_buf.len &&
+		    strncmp(method->name, method_buf.ptr, method_buf.len) == 0) {
 			matching_method = method;
 			break;
 		}


### PR DESCRIPTION
Verify length of method name, so that comparison between registered (from
application view) method name "app_method_2" is not invoked when there is
an RPC call of "app_method".