### PR TITLE
samples: lightdb: set: disable Golioth log backend in twister

### DIFF
--- a/samples/lightdb/set/sample.yaml
+++ b/samples/lightdb/set/sample.yaml
@@ -12,5 +12,3 @@ tests:
       nrf52840dk_nrf52840
       nrf9160dk_nrf9160_ns
       qemu_x86
-    extra_configs:
-      - CONFIG_LOG_BACKEND_GOLIOTH=y


### PR DESCRIPTION
Logs are not used during twister runtime test, so disable them.