### PR TITLE
logging: depend on LOG_MODE_IMMEDIATE

### DIFF
--- a/logging/Kconfig
+++ b/logging/Kconfig
@@ -7,7 +7,7 @@
 config LOG_BACKEND_GOLIOTH
 	bool "Golioth logging backend"
 	depends on LOG
-	depends on !LOG_IMMEDIATE
+	depends on !LOG_MODE_IMMEDIATE
 	depends on GOLIOTH
 	select LOG_OUTPUT
 	select ZCBOR


### PR DESCRIPTION
With Zephyr logging v2 there was an overhaul of Kconfig options. At first
old options were supported to some point. Right now there is no
`LOG_IMMEDIATE`, which `LOG_BACKEND_GOLIOTH` depended on.

Change `LOG_IMMEDIATE` to `LOG_MODE_IMMEDIATE`. This makes sure that for
platforms with synchronous logging by default (like recently introduced
`native_sim` in upstream Zephyr) Golioth logging backend doesn't get
enabled.