### PR TITLE
bump CI Docker images for gitlint and pre-commit

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: jorisroovers/gitlint:0.15.1
+      image: jorisroovers/gitlint:0.19.1
 
     steps:
       - uses: actions/checkout@v3
@@ -18,4 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitlint
-        run: gitlint --commits origin/main..
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          gitlint --commits origin/main..

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: kiwicom/pre-commit:2.9.3
+      image: kiwicom/pre-commit:3.0.4
 
     steps:
       - uses: actions/checkout@v3
@@ -19,6 +19,7 @@ jobs:
 
       - name: Run pre-commit
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           CODE=0 # run pre-commit
           for CID in `git rev-list --reverse origin/main..`; do
               git show $CID -s --format='    pre-commit %h ("%s")'


### PR DESCRIPTION
There is a newest version of that tool available, so simply use it.