### PR TITLE
gitlab-ci: use separate output directories for {non-,}golioth tests

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -43,21 +43,23 @@ jobs:
       - name: Run twister (non goliothd)
         run: >
           zephyr/scripts/twister
+          --no-clean
           -e goliothd
           -p esp32
           -p nrf52840dk_nrf52840
           -p qemu_x86
-          -o reports
+          -o reports/non_goliothd
           -T modules/lib/golioth
 
       - name: Run twister (goliothd)
         run: >
           zephyr/scripts/twister
+          --no-clean
           -t goliothd -b
           -p esp32
           -p nrf52840dk_nrf52840
           -p qemu_x86
-          -o reports
+          -o reports/goliothd
           -T modules/lib/golioth
 
       - name: Upload artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ pre-commit:
       - twister-out/**/build.log
       - twister-out/**/handler.log
     reports:
-      junit: reports/twister.xml
+      junit: reports/**/twister.xml
 
 #
 # Job depends on following environment variables:
@@ -166,31 +166,34 @@ twister-qemu-goliothd:
       -T modules/lib/golioth
   artifacts:
     reports:
-      junit: reports/twister_report.xml
+      junit: reports/**/twister_report.xml
 
 twister:
   extends: .twister
   script:
     - west blobs fetch hal_espressif
+    - rm -rf reports twister-out
     # Build and run all non-goliothd samples/tests
     - >
       zephyr/scripts/twister
       --force-color
+      --no-clean
       -e goliothd
       -p esp32
       -p nrf52840dk_nrf52840
       -p qemu_x86
-      -o reports
+      -o reports/non_goliothd
       -T modules/lib/golioth
     # Build-only all goliothd samples/tests
     - >
       zephyr/scripts/twister
       --force-color
+      --no-clean
       -t goliothd -b
       -p esp32
       -p nrf52840dk_nrf52840
       -p qemu_x86
-      -o reports
+      -o reports/goliothd
       -T modules/lib/golioth
 
 twister-ncs:


### PR DESCRIPTION
Since there were two invocations of twister in a row, first `twister-out`
directory was renamed during second invocation. Additionally `reports/`
directory contents from first run got overwritten with contents from second
run. This means that artifacts from first run were never accessible.

Run twister with `--no-clean` option, so that single `twister-out`
directory is used. Test sets from both runs are unique, which means that
the result will be a merged directory structure containing artifacts from
both runs.

Use separate `reports/` directory, so that reports from both runs are
uploaded and available to be investigated.