### PR TITLE
samples: hello_sporadic: minor project name cleanup

### DIFF
--- a/samples/hello_sporadic/CMakeLists.txt
+++ b/samples/hello_sporadic/CMakeLists.txt
@@ -3,6 +3,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello)
+project(hello_sporadic)
 
 target_sources(app PRIVATE src/main.c)

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -1,5 +1,5 @@
 Golioth Hello Sporadic sample
-####################
+#############################
 
 Overview
 ********

--- a/samples/hello_sporadic/sample.yaml
+++ b/samples/hello_sporadic/sample.yaml
@@ -1,6 +1,6 @@
 sample:
-  description: Say Hello to Golioth server
-  name: hello
+  description: Say Hello (sporadically) to Golioth server
+  name: hello_sporadic
 common:
   harness: net
   platform_allow: >
@@ -11,4 +11,4 @@ common:
     qemu_x86
   tags: golioth socket
 tests:
-  sample.golioth.hello: {}
+  sample.golioth.hello_sporadic: {}


### PR DESCRIPTION
`s/hello/hello_sporadic/` in few places, so that the project name is unique
in all contexts (cmake, twister, ...).

Fix README title adornment length.