### PR TITLE
Remove ZSOCK_MSG_TRUNC for offloaded TLS on nRF9160.

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -81,6 +81,14 @@ config MBEDTLS_MPI_MAX_SIZE
 	int
 	default 512 if GOLIOTH_AUTH_CERT_MBEDTLS_DEPS
 
+config GOLIOTH_RECV_USE_MSG_TRUNC
+	bool "Use MSG_TRUNC in recv()"
+	default y if NET_NATIVE && !NET_SOCKETS_OFFLOAD
+	help
+	  Use MSG_TRUNC flag in recv() API calls. This allows to receive truncated
+	  packets and renegotiate smaller blocks in CoAP packets in case configured
+	  receive buffer is too small.
+
 config GOLIOTH_HOSTNAME_VERIFICATION
 	bool "Hostname verification"
 	default y if GOLIOTH_AUTH_METHOD_CERT

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -529,11 +529,13 @@ static int golioth_recv(struct golioth_client *client, uint8_t *data,
 
 int golioth_process_rx(struct golioth_client *client)
 {
+	int flags = ZSOCK_MSG_DONTWAIT |
+		(IS_ENABLED(CONFIG_GOLIOTH_RECV_USE_MSG_TRUNC) ? ZSOCK_MSG_TRUNC : 0);
 	int ret;
 	int err;
 
 	ret = golioth_recv(client, client->rx_buffer, client->rx_buffer_len,
-			   ZSOCK_MSG_DONTWAIT | ZSOCK_MSG_TRUNC);
+			   flags);
 	if (ret == -EAGAIN || ret == -EWOULDBLOCK) {
 		/* no pending data */
 		return 0;


### PR DESCRIPTION
Creating an extra #ifdef conditional for handling recv flags when the connection socket is offloaded. ZSOCK_MSG_TRUNC is not supported on the nRF9160 modem firmware/library.

Fixes #417 

Signed-off-by: Jared Wolff (Circuit Dojo LLC)