### PR TITLE
samples: Use EXTRA_CONF_FILE instead of OVERLAY_CONFIG

### DIFF
--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -54,7 +54,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/hello/sample.yaml
+++ b/samples/hello/sample.yaml
@@ -74,4 +74,4 @@ tests:
       - CONFIG_GOLIOTH_AUTH_METHOD_CERT=y
   sample.golioth.hello.psk.runtime.buildonly:
     build_only: true
-    extra_args: OVERLAY_CONFIG="../common/runtime_psk.conf"
+    extra_args: EXTRA_CONF_FILE="../common/runtime_psk.conf"

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb/delete/README.rst
+++ b/samples/lightdb/delete/README.rst
@@ -50,7 +50,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb/get/README.rst
+++ b/samples/lightdb/get/README.rst
@@ -50,7 +50,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb/set/README.rst
+++ b/samples/lightdb/set/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/lightdb_stream/README.rst
+++ b/samples/lightdb_stream/README.rst
@@ -53,7 +53,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/logging/README.rst
+++ b/samples/logging/README.rst
@@ -51,7 +51,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 

--- a/samples/settings/README.rst
+++ b/samples/settings/README.rst
@@ -53,7 +53,7 @@ file:
 
 .. code-block:: console
 
-   $ west build -- -DOVERLAY_CONFIG=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
+   $ west build -- -DEXTRA_CONF_FILE=${ZEPHYR_GOLIOTH_MODULE_DIR}/samples/common/runtime_psk.conf
 
 Alternatively, you can add the following options to ``prj.conf``:
 


### PR DESCRIPTION
OVERLAY_CONFIG was deprecated in favor of EXTRA_CONF_FILE in 6a98c198d8f3