### PR TITLE
fw: don't log any error in case of no rolled out release

### DIFF
--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -123,7 +123,10 @@ int golioth_fw_desired_parse(const uint8_t *payload, uint16_t payload_len,
 
 	err = zcbor_map_decode(zsd, map_entries, ARRAY_SIZE(map_entries));
 	if (err) {
-		LOG_WRN("Failed to decode desired map");
+		if (err != -ENOENT) {
+			LOG_WRN("Failed to decode desired map");
+		}
+
 		return err;
 	}
 

--- a/net/golioth/zcbor_utils.c
+++ b/net/golioth/zcbor_utils.c
@@ -101,7 +101,7 @@ int zcbor_map_decode(zcbor_state_t *zsd,
 	struct zcbor_map_entry *entry;
 	size_t num_decoded = 0;
 	struct zcbor_map_key key;
-	int err;
+	int err = 0;
 	bool ok;
 
 	ok = zcbor_map_start_decode(zsd);
@@ -132,15 +132,21 @@ int zcbor_map_decode(zcbor_state_t *zsd,
 		}
 	}
 
+	if (num_decoded == 0) {
+		err = -ENOENT;
+		goto map_end_decode;
+	}
+
 	if (num_decoded < num_entries) {
 		return -EBADMSG;
 	}
 
+map_end_decode:
 	ok = zcbor_list_map_end_force_decode(zsd);
 	if (!ok) {
 		LOG_WRN("Did not end CBOR map correctly");
 		return -EBADMSG;
 	}
 
-	return 0;
+	return err;
 }

--- a/net/golioth/zcbor_utils.h
+++ b/net/golioth/zcbor_utils.h
@@ -83,6 +83,10 @@ int zcbor_map_tstr_decode(zcbor_state_t *zsd, void *value);
  * @param[inout] zsd          The current state of the decoding
  * @param[in]    entries      Array with entries to be decoded
  * @param[in]    num_entries  Number of entries (size of @a entries array)
+ *
+ * @retval  0       On success
+ * @retval -EBADMSG Failed to parse all map entries
+ * @retval <0       Other error returned from @ entries decode callback
  */
 int zcbor_map_decode(zcbor_state_t *zsd,
 		     struct zcbor_map_entry *entries,

--- a/net/golioth/zcbor_utils.h
+++ b/net/golioth/zcbor_utils.h
@@ -85,6 +85,7 @@ int zcbor_map_tstr_decode(zcbor_state_t *zsd, void *value);
  * @param[in]    num_entries  Number of entries (size of @a entries array)
  *
  * @retval  0       On success
+ * @retval -ENOENT  Map was empty
  * @retval -EBADMSG Failed to parse all map entries
  * @retval <0       Other error returned from @ entries decode callback
  */


### PR DESCRIPTION
Handle empty map in zcbor_map_decode() by returning `-ENOENT`, so that case can be handled by caller
differently than parsing errors.

Don't log any error in case of no rolled out release. Bring back the same behavior when QCBOR was
used and `-ENOENT` was returned without producing any logs.

Fixes: d6b33f5c9af0 ("fw: convert from QCBOR to zcbor")