### PR TITLE
bump NCS to 2.4.1

### DIFF
--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: v2.4.0
+      revision: v2.4.1
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 


### PR DESCRIPTION
This release has just few bugfix commits, so the impact should be minimal.
Among other things, there is a fix for nRF53 (which is a host MCU on
nRF7002-DK) that might be useful for downstream users.