### PR TITLE
bump Zephyr to 3.5.0-rc3 and NCS to tip of main (2.5.0-rc1+)

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,7 +26,7 @@ jobs:
           - qemu_x86
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: modules/lib/golioth
 
@@ -67,7 +67,7 @@ jobs:
           -T modules/lib/golioth
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: twister-artifacts

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,14 @@ jobs:
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
 
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - esp32_devkitc_wroom
+          - nrf52840dk_nrf52840
+          - qemu_x86
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,9 +53,7 @@ jobs:
           zephyr/scripts/twister
           --no-clean
           -e goliothd
-          -p esp32_devkitc_wroom
-          -p nrf52840dk_nrf52840
-          -p qemu_x86
+          -p ${{ matrix.board }}
           -o reports/non_goliothd
           -T modules/lib/golioth
 
@@ -56,9 +62,7 @@ jobs:
           zephyr/scripts/twister
           --no-clean
           -t goliothd -b
-          -p esp32_devkitc_wroom
-          -p nrf52840dk_nrf52840
-          -p qemu_x86
+          -p ${{ matrix.board }}
           -o reports/goliothd
           -T modules/lib/golioth
 

--- a/net/golioth/CMakeLists.txt
+++ b/net/golioth/CMakeLists.txt
@@ -56,3 +56,7 @@ if(CONFIG_ZCBOR)
     zephyr_library_sources(zcbor_any_skip_fixed.c)
   endif()
 endif()
+
+if(NOT EXISTS ${ZEPHYR_BASE}/include/zephyr/random/random.h)
+  zephyr_library_include_directories(include_random)
+endif()

--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -9,7 +9,7 @@ LOG_MODULE_DECLARE(golioth);
 
 #include <stdlib.h>
 
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include "coap_req.h"
 #include "coap_utils.h"

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <zephyr/net/socket.h>
-#include <zephyr/random/rand32.h>
+#include <zephyr/random/random.h>
 
 #include <golioth_ciphersuites.h>
 

--- a/net/golioth/include_random/zephyr/random/random.h
+++ b/net/golioth/include_random/zephyr/random/random.h
@@ -1,0 +1,1 @@
+#include <zephyr/random/rand32.h>

--- a/patches/west-zephyr/zephyr/0001-twister-support-attach_serial_after_flash-in-hardwar.patch
+++ b/patches/west-zephyr/zephyr/0001-twister-support-attach_serial_after_flash-in-hardwar.patch
@@ -26,13 +26,12 @@ Signed-off-by: Marcin Niestroj <m.niestroj@emb.dev>
 ---
  scripts/pylib/twister/twisterlib/handlers.py  | 61 ++++++++++++-------
  .../pylib/twister/twisterlib/hardwaremap.py   |  4 ++
- scripts/pylib/twister/twisterlib/runner.py    |  2 +-
  scripts/schemas/twister/hwmap-schema.yaml     |  3 +
  subsys/net/conn_mgr/events_handler.c          |  4 +-
- 5 files changed, 48 insertions(+), 26 deletions(-)
+ 4 files changed, 47 insertions(+), 25 deletions(-)
 
 diff --git a/scripts/pylib/twister/twisterlib/handlers.py b/scripts/pylib/twister/twisterlib/handlers.py
-index 780b51cb7d..fd991aa802 100755
+index e4a0d9f5a1..76058bf0e2 100755
 --- a/scripts/pylib/twister/twisterlib/handlers.py
 +++ b/scripts/pylib/twister/twisterlib/handlers.py
 @@ -630,23 +630,33 @@ class DeviceHandler(Handler):
@@ -175,19 +174,6 @@ index 5e90b7c84c..e8167035a8 100644
                            connected=connected,
                            pre_script=pre_script,
                            post_script=post_script,
-diff --git a/scripts/pylib/twister/twisterlib/runner.py b/scripts/pylib/twister/twisterlib/runner.py
-index ef41084cdd..fbffa817bb 100644
---- a/scripts/pylib/twister/twisterlib/runner.py
-+++ b/scripts/pylib/twister/twisterlib/runner.py
-@@ -1052,7 +1052,7 @@ class ProjectBuilder(FilterBuilder):
-             harness = HarnessImporter.get_harness(instance.testsuite.harness.capitalize())
-             harness.configure(instance)
-             if isinstance(harness, Pytest):
--                harness.pytest_run(instance.handler.timeout)
-+                harness.pytest_run(instance.handler.get_test_timeout())
-             else:
-                 instance.handler.handle(harness)
- 
 diff --git a/scripts/schemas/twister/hwmap-schema.yaml b/scripts/schemas/twister/hwmap-schema.yaml
 index 3ecb064ddf..6e79b5da97 100644
 --- a/scripts/schemas/twister/hwmap-schema.yaml

--- a/west-ncs.yml
+++ b/west-ncs.yml
@@ -3,7 +3,7 @@
 manifest:
   projects:
     - name: nrf
-      revision: de0cba7da536ede9c037bac17336ad73d048117d  # post v2.4.99-dev2
+      revision: cc103cdb918ec65595c1819a0c4c5a083ef1a233  # post v2.5.0-rc1
       url: http://github.com/nrfconnect/sdk-nrf
       import: true
 

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: v3.5.0-rc1
+      revision: v3.5.0-rc3
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import: true


### PR DESCRIPTION
Bump Zephyr to latest release candidate to test it before final 3.5.0
release.

Bump NCS to tip of main (slightly newer than 2.5.0-rc1 tag), to find
potential nRF91* platform regressions.

Replace `rand32.h` with `random.h` to suppress header deprecation warning. Add
a workaround for older Zephyr versions (like the one used by NCS fork) by
providing `random.h` just for internal Golioth SDK library visibility.

Tested on:
- [x] `qemu_x86`
- [x] `nrf52840dk_nrf52840`
- [x] `mimxrt1060_evkb`
- [x] `esp32_devkitc_wroom`
- [x] `nrf9160dk_nrf9160_ns`