### PR TITLE
github-ci: use matrix to parallelize jobs

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,7 +26,7 @@ jobs:
           - qemu_x86
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: modules/lib/golioth
 
@@ -67,7 +67,7 @@ jobs:
           -T modules/lib/golioth
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: twister-artifacts

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,6 +17,14 @@ jobs:
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
 
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - esp32_devkitc_wroom
+          - nrf52840dk_nrf52840
+          - qemu_x86
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,9 +53,7 @@ jobs:
           zephyr/scripts/twister
           --no-clean
           -e goliothd
-          -p esp32_devkitc_wroom
-          -p nrf52840dk_nrf52840
-          -p qemu_x86
+          -p ${{ matrix.board }}
           -o reports/non_goliothd
           -T modules/lib/golioth
 
@@ -56,9 +62,7 @@ jobs:
           zephyr/scripts/twister
           --no-clean
           -t goliothd -b
-          -p esp32_devkitc_wroom
-          -p nrf52840dk_nrf52840
-          -p qemu_x86
+          -p ${{ matrix.board }}
           -o reports/goliothd
           -T modules/lib/golioth
 


### PR DESCRIPTION
Use matrix of boards to parallelize jobs across multiple runners. This will also reduce amount of disk space needed at the end.

Clean push of https://github.com/golioth/golioth-zephyr-sdk/pull/439