### PR TITLE
bump Zephyr to 3.5.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,8 +156,8 @@ During release testing, all boards and services are verified using sample applic
 +------------------+--------------+-------------+----------+
 
 .. _Zephyr RTOS: https://www.zephyrproject.org/
-.. _west: https://docs.zephyrproject.org/3.4.0/develop/west/index.html
-.. _Zephyr Getting Started: https://docs.zephyrproject.org/3.4.0/develop/getting_started/index.html
+.. _west: https://docs.zephyrproject.org/3.5.0/develop/west/index.html
+.. _Zephyr Getting Started: https://docs.zephyrproject.org/3.5.0/develop/getting_started/index.html
 .. _nRF Connect SDK: https://www.nordicsemi.com/Software-and-tools/Software/nRF-Connect-SDK
 .. _nRF Connect SDK Getting Started: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html
 .. _nRF9160 DK: https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk

--- a/samples/certificate_provisioning/README.rst
+++ b/samples/certificate_provisioning/README.rst
@@ -46,7 +46,7 @@ sample application (i.e. ``samples/certificate_provisioning``) and type:
    $ west build -b esp32_devkitc_wroom samples/certificate_provisioning
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -214,7 +214,7 @@ This is the output from the serial console:
     [00:00:15.833,404] <inf> golioth_hello: Sending hello! 1
     [00:00:20.833,496] <inf> golioth_hello: Sending hello! 2
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _mcumgr: https://docs.zephyrproject.org/latest/services/device_mgmt/mcumgr.html
 .. _golioth cert auth: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/certificate-auth

--- a/samples/dfu/README.rst
+++ b/samples/dfu/README.rst
@@ -335,7 +335,7 @@ Related documentation:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _MCUboot: https://docs.zephyrproject.org/3.4.0/services/device_mgmt/dfu.html#mcuboot
-.. _Signing Binaries: https://docs.zephyrproject.org/3.4.0/develop/west/sign.html#west-sign
-.. _Flash map: https://docs.zephyrproject.org/3.4.0/services/storage/flash_map/flash_map.html
+.. _MCUboot: https://docs.zephyrproject.org/3.5.0/services/device_mgmt/dfu.html#mcuboot
+.. _Signing Binaries: https://docs.zephyrproject.org/3.5.0/develop/west/sign.html#west-sign
+.. _Flash map: https://docs.zephyrproject.org/3.5.0/services/storage/flash_map/flash_map.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/hello/README.rst
+++ b/samples/hello/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/hello``) and type:
    $ west build -b esp32_devkitc_wroom samples/hello
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -228,6 +228,6 @@ means that communication with Golioth is working.
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/hello_sporadic/README.rst
+++ b/samples/hello_sporadic/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/hello_sporadic``) and type:
    $ west build -b esp32_devkitc_wroom samples/hello_sporadic
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -235,6 +235,6 @@ This is the output from the serial console:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/delete/README.rst
+++ b/samples/lightdb/delete/README.rst
@@ -137,7 +137,7 @@ sample application (i.e., ``samples/lightdb/delete``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb/delete
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -240,6 +240,6 @@ The value can be set with:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/get/README.rst
+++ b/samples/lightdb/get/README.rst
@@ -137,7 +137,7 @@ sample application (i.e., ``samples/lightdb/get``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb/get
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -246,6 +246,6 @@ The value can be set with:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/observe/README.rst
+++ b/samples/lightdb/observe/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/lightdb/observe``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb/observe
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -240,6 +240,6 @@ retrieves it every time that it's updated. The value can be updates as such:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb/set/README.rst
+++ b/samples/lightdb/set/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/lightdb/set``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb/set
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -245,6 +245,6 @@ with its value. Current value can be fetched using following command:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb_led/README.rst
+++ b/samples/lightdb_led/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/lightdb_led``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb_led
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -261,6 +261,6 @@ as:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/lightdb_stream/README.rst
+++ b/samples/lightdb_stream/README.rst
@@ -140,7 +140,7 @@ sample application (i.e., ``samples/lightdb_stream``) and type:
    $ west build -b esp32_devkitc_wroom samples/lightdb_stream
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -323,6 +323,6 @@ Historical data can be queried using following command:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/logging/README.rst
+++ b/samples/logging/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/logging``) and type:
    $ west build -b esp32_devkitc_wroom samples/logging
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -265,6 +265,6 @@ This is how logs are visible
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/samples/rpc/README.rst
+++ b/samples/rpc/README.rst
@@ -138,7 +138,7 @@ sample application (i.e., ``samples/rpc``) and type:
    $ west build -b esp32_devkitc_wroom samples/rpc
    $ west flash
 
-See `ESP32`_ for details on how to use ESP32 board.
+See `ESP32-DEVKITC-WROOM`_ for details on how to use ESP32 board.
 
 nRF52840 DK + ESP32-WROOM-32
 ----------------------------
@@ -232,6 +232,6 @@ This is the output from the serial console:
 
 .. _authentication methods: https://docs.golioth.io/firmware/zephyr-device-sdk/authentication/
 .. _Zephyr Settings subsystem: https://docs.zephyrproject.org/latest/services/settings/index.html
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
-.. _ESP32: https://docs.zephyrproject.org/3.4.0/boards/xtensa/esp32/doc/index.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html
+.. _ESP32-DEVKITC-WROOM: https://docs.zephyrproject.org/3.5.0/boards/xtensa/esp32_devkitc_wroom/doc/index.html
 .. _AT Binary Lists: https://docs.espressif.com/projects/esp-at/en/latest/AT_Binary_Lists/index.html

--- a/tests/lightdb/README.rst
+++ b/tests/lightdb/README.rst
@@ -34,4 +34,4 @@ Run ``twister``:
 
    zephyr/scripts/twister -p qemu_x86 -T modules/lib/golioth/tests/lightdb
 
-.. _Networking with QEMU: https://docs.zephyrproject.org/3.4.0/connectivity/networking/qemu_setup.html
+.. _Networking with QEMU: https://docs.zephyrproject.org/3.5.0/connectivity/networking/qemu_setup.html

--- a/west-zephyr.yml
+++ b/west-zephyr.yml
@@ -1,7 +1,7 @@
 manifest:
   projects:
     - name: zephyr
-      revision: v3.5.0-rc3
+      revision: v3.5.0
       url: https://github.com/zephyrproject-rtos/zephyr
       west-commands: scripts/west-commands.yml
       import: true


### PR DESCRIPTION
This is the latest stable release, with mostly documentation updates
compared to -rc3.