### PR TITLE
ci: use minimal docker image for build test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,8 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container:
-      image: zephyrprojectrtos/ci:v0.26.5
+    container: golioth/golioth-zephyr-base:0.16.3-SDK-v0
 
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
@@ -43,6 +42,12 @@ jobs:
           git config --global user.email user@git-scm.com
           git config --global user.name "Git User"
           west patch
+
+          pip3 install -r zephyr/scripts/requirements-base.txt
+          pip3 install -r zephyr/scripts/requirements-build-test.txt
+          pip3 install -r zephyr/scripts/requirements-run-test.txt
+          # Needed for TF-M
+          pip3 install cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
 
       - name: Download binary blobs
         run: |


### PR DESCRIPTION
Use a Golioth created docker image for build test instead of Zephyr project image. The Golioth image only contains the tools that we need to build our supported boards, so it is smaller and faster than the Zephyr image.