### PR TITLE
dtls: enable DTLS 1.2 Connection IDs

### DIFF
--- a/net/golioth/Kconfig
+++ b/net/golioth/Kconfig
@@ -27,6 +27,15 @@ module = GOLIOTH
 module-str = golioth
 source "subsys/logging/Kconfig.template.log_config"
 
+config GOLIOTH_USE_CONNECTION_ID
+	bool "Use DTLS 1.2 Connection IDs"
+	select MBEDTLS_SSL_DTLS_CONNECTION_ID
+	help
+	  Use DTLS 1.2 Connection IDs. Connection IDs replace IP
+	  addresses as the session identifier, and can be used to
+	  reduce the number of handshakes a device has to make in
+	  certain scenarios.
+
 choice GOLIOTH_AUTH_METHOD
 	prompt "Authentication method support"
 

--- a/net/golioth/golioth.c
+++ b/net/golioth/golioth.c
@@ -90,6 +90,18 @@ static int golioth_setsockopt_dtls(struct golioth_client *client, int sock,
 		}
 	}
 
+	/* If Connection IDs are enabled, set socket option to send CIDs, but not require that the
+	 * server sends one in return.
+	 */
+#ifdef CONFIG_GOLIOTH_USE_CONNECTION_ID
+	int enabled = 1;
+
+	ret = zsock_setsockopt(sock, SOL_TLS, TLS_DTLS_CID, &enabled, sizeof(enabled));
+	if (ret < 0) {
+		return -errno;
+	}
+#endif /* CONFIG_GOLIOTH_USE_CONNECTION_ID */
+
 	return 0;
 }
 

--- a/samples/hello/sample.yaml
+++ b/samples/hello/sample.yaml
@@ -56,6 +56,19 @@ tests:
       - CONFIG_MBEDTLS_CIPHER_CCM_ENABLED=y
       - CONFIG_MBEDTLS_CIPHER_MODE_CBC_ENABLED=n
       - CONFIG_GOLIOTH_CIPHERSUITES="TLS_PSK_WITH_AES_128_CCM_8"
+  sample.golioth.hello.psk.fast.cid:
+    platform_allow: >
+      esp32_devkitc_wroom
+      mimxrt1060_evkb
+      nrf52840dk_nrf52840
+      qemu_x86
+    extra_configs:
+      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
+  sample.golioth.hello.psk.long_start.cid:
+    platform_allow: nrf9160dk_nrf9160_ns
+    timeout: 120
+    extra_configs:
+      - CONFIG_GOLIOTH_USE_CONNECTION_ID=y
   sample.golioth.hello.psk.long_start:
     platform_allow: nrf9160dk_nrf9160_ns
     timeout: 120


### PR DESCRIPTION
Enable Connection ID support, which enables deviecs to maintain their connection with the server for longer periods and across IP address changes, resulting in lower bandwidth and reduced power usage.