### PR TITLE
ci: catch ram overflow build failures

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Run twister (non goliothd)
         run: >
           zephyr/scripts/twister
+          --overflow-as-errors
           --no-clean
           -e goliothd
           -p ${{ matrix.board }}
@@ -60,6 +61,7 @@ jobs:
       - name: Run twister (goliothd)
         run: >
           zephyr/scripts/twister
+          --overflow-as-errors
           --no-clean
           -t goliothd -b
           -p ${{ matrix.board }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,7 @@ twister-qemu-goliothd:
       zephyr/scripts/twister
       --force-color
       -vvv
+      --overflow-as-errors
       -t goliothd
       -j 1
       -p qemu_x86
@@ -176,6 +177,7 @@ twister:
       zephyr/scripts/twister
       --force-color
       --no-clean
+      --overflow-as-errors
       -e goliothd
       -p esp32_devkitc_wroom
       -p nrf52840dk_nrf52840
@@ -187,6 +189,7 @@ twister:
       zephyr/scripts/twister
       --force-color
       --no-clean
+      --overflow-as-errors
       -t goliothd -b
       -p esp32_devkitc_wroom
       -p nrf52840dk_nrf52840
@@ -202,6 +205,7 @@ twister-ncs:
     - >
       zephyr/scripts/twister
       --force-color
+      --overflow-as-errors
       -p nrf9160dk_nrf9160_ns
       -o reports
       -T $MODULE_PATH


### PR DESCRIPTION
Twister treats overflows in the RAM during builds as "skipped" tests instead of errors by default. Enabling the `--overflow-as-errors` option ensures we can catch overflows in CI.