### PR TITLE
workflows: used is_active to select runner

### DIFF
--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -92,7 +92,7 @@ jobs:
   #   export CI_NRF52840DK_SNR=723769314
   hw_flash_and_test:
     needs: build_for_hw_test
-    runs-on: [self-hosted, has_nrf52840dk]
+    runs-on: [is_active, has_nrf52840dk]
 
     defaults:
       run:

--- a/.github/workflows/test_nrf9160dk.yml
+++ b/.github/workflows/test_nrf9160dk.yml
@@ -97,7 +97,7 @@ jobs:
   #   export CI_NRF9160DK_SNR=723769314
   hw_flash_and_test:
     needs: build_for_hw_test
-    runs-on: [self-hosted, has_nrf9160dk]
+    runs-on: [is_active, has_nrf9160dk]
 
     defaults:
       run:


### PR DESCRIPTION
Target self-hosted runners using the `is_active` label. We added this label to all of our self-hosted runners to indicate they are ready to be assigned CI tests. Removing this label (for maintenance or testing) from a runner removes it from the CI loop.