### PR TITLE
samples: dfu: add log for different release number

### DIFF
--- a/samples/dfu/src/main.c
+++ b/samples/dfu/src/main.c
@@ -130,6 +130,9 @@ static int golioth_desired_update(struct golioth_req_rsp *rsp)
 		LOG_INF("Desired version (%s) matches current firmware version!",
 			current_version_str);
 		return -EALREADY;
+	} else {
+		LOG_INF("Server advertises %s as latest version. Beginning download.",
+			dfu->version);
 	}
 
 	uri_p = uri_strip_leading_slash(uri, &uri_len);


### PR DESCRIPTION
Add message when a release number is received from Golioth that doesn't match what is currently running. This indicates an OTA firmware update should be performed (it will either be an update or a rollback). This change compliments the message we log when the received semantic version matches what is currently running on the device.