### PR TITLE
coap_req: fix use alloc/free issues

### DIFF
--- a/net/golioth/coap_req.c
+++ b/net/golioth/coap_req.c
@@ -512,7 +512,7 @@ int golioth_coap_req_cb(struct golioth_client *client,
 				   cb, user_data);
 	if (err) {
 		LOG_ERR("Failed to create new CoAP GET request: %d", err);
-		goto free_req;
+		return err;
 	}
 
 	if (method == COAP_METHOD_GET && (flags & GOLIOTH_COAP_REQ_OBSERVE)) {

--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -164,7 +164,12 @@ int golioth_fw_download(struct golioth_client *client,
 		goto free_req;
 	}
 
-	return golioth_coap_req_schedule(req);
+	err = golioth_coap_req_schedule(req);
+	if (err) {
+		goto free_req;
+	}
+
+	return 0;
 
 free_req:
 	golioth_coap_req_free(req);

--- a/net/golioth/fw.c
+++ b/net/golioth/fw.c
@@ -155,7 +155,7 @@ int golioth_fw_download(struct golioth_client *client,
 				   cb, user_data);
 	if (err) {
 		LOG_ERR("Failed to initialize CoAP GET request: %d", err);
-		goto free_req;
+		return err;
 	}
 
 	err = coap_packet_append_uri_path_from_string(&req->request, uri, uri_len);


### PR DESCRIPTION
Fix undefined behavior related to `free()` of uninitialized pointer. Just
return early when allocation with `golioth_coap_req_new()` has failed.

Free `coap_req` when scheduling it for sending has failed.