### PR TITLE
workflows: add USB hub control to workflows

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -13,7 +13,7 @@ jobs:
       image: zephyrprojectrtos/ci:v0.26.5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: modules/lib/golioth
           fetch-depth: 0

--- a/.github/workflows/firebase-doxygen-main.yml
+++ b/.github/workflows/firebase-doxygen-main.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/firebase-doxygen-pr.yml
+++ b/.github/workflows/firebase-doxygen-pr.yml
@@ -4,7 +4,7 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt install doxygen graphviz
       - name: Generate Doxygen

--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -13,7 +13,7 @@ jobs:
       image: jorisroovers/gitlint:0.19.1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
       image: kiwicom/pre-commit:3.0.4
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -21,7 +21,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: modules/lib/golioth
 
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: connection_tests
 

--- a/.github/workflows/test_nrf52840dk.yml
+++ b/.github/workflows/test_nrf52840dk.yml
@@ -98,11 +98,23 @@ jobs:
       run:
         working-directory: connection_tests
 
+    container:
+      image: golioth/golioth-twister-base:8307b9c
+      env:
+        ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
         with:
           path: connection_tests
+
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
 
       - name: Download build tarball
         uses: actions/download-artifact@v3
@@ -117,15 +129,27 @@ jobs:
 
       - name: Copy credentials to samples/test
         run: |
-          cp $HOME/credentials_nrf52840dk.yml samples/test/credentials.yml
+          cp /opt/credentials/credentials_nrf52840dk.yml samples/test/credentials.yml
 
       - name: Flash and Verify Test Results
+        shell: bash
         run: |
           cd samples/test
-          source $HOME/runner_env.sh
+          source /opt/credentials/runner_env.sh
           nrfjprog --recover -f NRF52 --snr $CI_NRF52840DK_SNR
           nrfjprog --program build/zephyr/zephyr.hex --sectoranduicrerase --verify -f NRF52 --snr $CI_NRF52840DK_SNR
           nrfjprog --pinresetenable -f NRF52 --snr $CI_NRF52840DK_SNR
           nrfjprog --pinreset -f NRF52 --snr $CI_NRF52840DK_SNR
           sleep 3
-          python verify.py $CI_NRF52840DK_PORT
+          python3 verify.py $CI_NRF52840DK_PORT
+
+      - name: Erase flash
+        if: always()
+        shell: bash
+        run: |
+          source /opt/credentials/runner_env.sh
+          nrfjprog --recover --snr ${CI_NRF52840DK_SNR}
+
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test_nrf9160dk.yml
+++ b/.github/workflows/test_nrf9160dk.yml
@@ -99,6 +99,15 @@ jobs:
     needs: build_for_hw_test
     runs-on: [is_active, has_nrf9160dk]
 
+    container:
+      image: golioth/golioth-twister-base:8307b9c
+      env:
+        ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
+      volumes:
+        - /dev:/dev
+        - /home/golioth/credentials:/opt/credentials
+      options: --privileged
+
     defaults:
       run:
         working-directory: connection_tests
@@ -108,6 +117,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: connection_tests
+
+      - name: Power On USB Hub
+        run: python3 /opt/golioth-scripts/usb_hub_power.py on
 
       - name: Download build tarball
         uses: actions/download-artifact@v3
@@ -122,16 +134,28 @@ jobs:
 
       - name: Copy credentials to samples/test
         run: |
-          cp $HOME/credentials_nrf9160dk.yml samples/test/credentials.yml
+          cp /opt/credentials/credentials_nrf9160dk.yml samples/test/credentials.yml
 
       - name: Flash and Verify Test Results
+        shell: bash
         run: |
           cd samples/test
-          source $HOME/runner_env.sh
+          source /opt/credentials/runner_env.sh
           nrfjprog --recover -f NRF91 --snr $CI_NRF9160DK_SNR
           nrfjprog --eraseall -f NRF91 --snr $CI_NRF9160DK_SNR
           nrfjprog --program build/zephyr/merged.hex --verify -f NRF91 --snr $CI_NRF9160DK_SNR
           nrfjprog --pinreset -f NRF91 --snr $CI_NRF9160DK_SNR
           sleep 3
           # Add a longer timeout to verify step for LTE connection
-          python verify.py $CI_NRF9160DK_PORT --timeout 300
+          python3 verify.py $CI_NRF9160DK_PORT --timeout 300
+
+      - name: Erase flash
+        if: always()
+        shell: bash
+        run: |
+          source /opt/credentials/runner_env.sh
+          nrfjprog --recover --snr ${CI_NRF9160DK_SNR}
+
+      - name: Power Off USB Hub
+        if: always()
+        run: python3 /opt/golioth-scripts/usb_hub_power.py off

--- a/.github/workflows/test_nrf9160dk.yml
+++ b/.github/workflows/test_nrf9160dk.yml
@@ -28,7 +28,7 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.16.3
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: modules/lib/golioth
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: connection_tests
 

--- a/samples/test/verify.py
+++ b/samples/test/verify.py
@@ -19,7 +19,7 @@ def wait_for_regex_in_line(ser, regex, timeout_s=20, log=True):
             return regex_search
 
 def set_setting(ser, key, value):
-    ser.write('\r\n'.encode())
+    ser.write('\r\n\r\n'.encode())
     wait_for_regex_in_line(ser, 'uart:', log=False)
     ser.write('settings set {} {}\r\n'.format(key, value).encode())
     wait_for_regex_in_line(ser, 'saved', log=False)
@@ -34,7 +34,7 @@ def set_credentials(ser):
         set_setting(ser, key, value)
 
 def reset(ser):
-    ser.write('\r\n'.encode())
+    ser.write('\r\n\r\n'.encode())
     wait_for_regex_in_line(ser, 'uart:')
     ser.write('kernel reboot cold\r\n'.encode())
     # Wait for string that prints on next boot


### PR DESCRIPTION
By default, USB hubs are turned off after tests. Update workflows that run on HIL to turn on the hub at the start of the test, and erase and turn off the hub after it runs.

resolve https://github.com/golioth/firmware-issue-tracker/issues/501