### PR TITLE
update recv_expiry when there is a network event

### DIFF
--- a/net/golioth/system_client.c
+++ b/net/golioth/system_client.c
@@ -362,6 +362,7 @@ static void golioth_system_client_main(void *arg1, void *arg2, void *arg3)
 			(void)eventfd_read(fds[POLLFD_EVENT].fd,
 					   &eventfd_value);
 			LOG_DBG("Event in eventfd");
+			recv_expiry = k_uptime_get() + RECV_TIMEOUT;
 			event_occurred = true;
 		}
 


### PR DESCRIPTION
[As reported by a user](https://forum.golioth.io/t/lots-of-client-timeouts/581):
Client timeouts when there is no network traffic apart from sending a ping to the Server.

Having the value of `GOLIOTH_SYSTEM_CLIENT_PING_INTERVAL_SEC` smaller than the `GOLIOTH_SYSTEM_CLIENT_RX_TIMEOUT_SEC` results in a receive timeout, after which the connection is re-established.